### PR TITLE
ContainerApps: Link resources with an application

### DIFF
--- a/reference-apps/container-app-store/iac/infra-azure.bicep
+++ b/reference-apps/container-app-store/iac/infra-azure.bicep
@@ -28,6 +28,7 @@ resource statestore 'Applications.Connector/daprStateStores@2022-03-15-privatepr
   location: 'global'
   properties: {
     kind:  'state.azure.tablestorage'
+    application: applicationId
     environment: environment
     resource: account::tableServices::table.id 
   }

--- a/reference-apps/container-app-store/iac/infra-selfhosted.bicep
+++ b/reference-apps/container-app-store/iac/infra-selfhosted.bicep
@@ -36,6 +36,7 @@ resource statestore 'Applications.Connector/daprStateStores@2022-03-15-privatepr
   properties: {
     kind:  'generic'
     type: 'state.redis'
+    application: applicationId
     environment: environment
     version: 'v1'
     metadata: {


### PR DESCRIPTION
Limiting scope of all resources to the sample application so that the resources that were created are deleted when a user deletes the sample app.

https://github.com/project-radius/radius/issues/3321