### PR TITLE
Reduce size of tutorial image

### DIFF
--- a/tutorial/Dockerfile
+++ b/tutorial/Dockerfile
@@ -1,12 +1,17 @@
-FROM node:14
-
+FROM node:18-buster as BUILD
 WORKDIR /usr/src/app
 
 COPY package*.json ./
-RUN npm install
+RUN npm ci && npm cache clean --force
 
 COPY . .
 RUN npm run build
+
+FROM node:18-alpine
+WORKDIR /usr/src/app
+
+COPY --from=BUILD /usr/src/app/dist ./dist
+COPY --from=BUILD /usr/src/app/node_modules ./node_modules
 
 EXPOSE 3000
 CMD [ "node", "dist/server.js" ]


### PR DESCRIPTION
This change reduces the size of the tutorial container image by ~300mb by switching to a smaller base image and doing a two-stage build. The base image swap is responsible for about ~275mb of savings.

Fixes https://github.com/project-radius/radius/issues/1139