### PR TITLE
Use Redis FQDN in quickstart bicep

### DIFF
--- a/quickstarts/dapr/dapr.bicep
+++ b/quickstarts/dapr/dapr.bicep
@@ -20,7 +20,7 @@ resource backend 'Applications.Core/containers@2022-03-15-privatepreview' = {
   properties: {
     application: app.id
     container: {
-      image: 'radius.azurecr.io/quickstarts/dapr-backend:0.13'
+      image: 'radius.azurecr.io/quickstarts/dapr-backend:edge'
       ports: {
         web: {
           containerPort: 3000
@@ -59,7 +59,7 @@ resource frontend 'Applications.Core/containers@2022-03-15-privatepreview' = {
   properties: {
     application: app.id
     container: {
-      image: 'radius.azurecr.io/quickstarts/dapr-frontend:0.13'
+      image: 'radius.azurecr.io/quickstarts/dapr-frontend:edge'
       ports: {
         ui: {
           containerPort: 80


### PR DESCRIPTION
Use Redis FQDN in quickstart bicep.

Fixes https://github.com/project-radius/radius/issues/4849