### PR TITLE
Making tutorial match docs version

### DIFF
--- a/tutorial/app.bicep
+++ b/tutorial/app.bicep
@@ -1,3 +1,4 @@
+//APPBASE
 import radius as radius
 
 param environment string
@@ -9,7 +10,9 @@ resource app 'Applications.Core/applications@2022-03-15-privatepreview' = {
     environment: environment
   }
 }
+//APPBASE
 
+//CONTAINER
 resource frontend 'Applications.Core/containers@2022-03-15-privatepreview' = {
   name: 'frontend'
   location: 'global'
@@ -39,7 +42,9 @@ resource frontendRoute 'Applications.Core/httpRoutes@2022-03-15-privatepreview' 
     application: app.id
   }
 }
+//CONTAINER
 
+//GATEWAY
 resource gateway 'Applications.Core/gateways@2022-03-15-privatepreview' = {
   name: 'public'
   location: 'global'
@@ -53,7 +58,9 @@ resource gateway 'Applications.Core/gateways@2022-03-15-privatepreview' = {
     ]
   }
 }
+//GATEWAY
 
+//DATABASE LINK
 resource db 'Applications.Link/mongoDatabases@2022-03-15-privatepreview' = {
   name: 'db'
   location: 'global'
@@ -61,14 +68,18 @@ resource db 'Applications.Link/mongoDatabases@2022-03-15-privatepreview' = {
     environment: app.properties.environment
     application: app.id
     mode: 'values'
-    host: mongo.outputs.name
+    host: mongo.outputs.host
     port: mongo.outputs.port
     secrets: {
-      connectionString: 'mongodb://${mongo.outputs.name}:${mongo.outputs.port}/${mongo.outputs.dbName}?authSource=admin'
+      // Manually build the link from the connectionString value
+      connectionString: mongo.outputs.connectionString
     }
   }
 }
+//DATABASE LINK
 
+//MONGOMODULE
 module mongo 'mongo-container.bicep' = {
   name: 'mongo-module'
 }
+//MONGOMODULE

--- a/tutorial/azure-cosmosdb.bicep
+++ b/tutorial/azure-cosmosdb.bicep
@@ -1,9 +1,9 @@
 import radius as radius
 
 param location string
-
 param name string = 'todoapp-cosmos-${uniqueString(resourceGroup().id)}'
 
+//COSMOS
 resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2021-04-15' = {
   name: toLower(name)
   location: location
@@ -33,5 +33,6 @@ resource cosmosAccount 'Microsoft.DocumentDB/databaseAccounts@2021-04-15' = {
   }
 
 }
+//COSMOS
 
 output cosmosDatabaseId string = cosmosAccount::cosmosDb.id

--- a/tutorial/mongo-container.bicep
+++ b/tutorial/mongo-container.bicep
@@ -1,3 +1,4 @@
+//MONGO
 import kubernetes as kubernetes {
   kubeConfig: ''
   namespace: namespace
@@ -8,6 +9,7 @@ param name string = 'mongo'
 
 var port = 27017
 
+//SS
 resource statefulset 'apps/StatefulSet@v1' = {
   metadata: {
     name: name
@@ -97,6 +99,33 @@ resource statefulset 'apps/StatefulSet@v1' = {
     ]
   }
 }
+//SS
+//SERVICE
+resource service 'core/Service@v1' = {
+  metadata: {
+    name: name
+    labels: {
+      app: name
+    }
+  }
+  spec: {
+    clusterIP: 'None'
+    ports: [
+      {
+        port: port
+      }
+    ]
+    selector: {
+      app: name
+    }
+  }
+}
+//SERVICE
+
+output host string = name
+output port int = int(port)
+output connectionString string = 'mongodb://${name}.${namespace}.svc.cluster.local:${port}/${name}?authSource=admin'
+//MONGO
 
 resource sa 'core/ServiceAccount@v1' = {
   metadata: {
@@ -157,29 +186,3 @@ resource secret 'core/Secret@v1' = {
     connectionString: 'mongodb://${name}.${namespace}.svc.cluster.local:${port}/${name}?authSource=admin'
   }
 }
-
-resource service 'core/Service@v1' = {
-  metadata: {
-    name: name
-    labels: {
-      app: name
-    }
-  }
-  spec: {
-    clusterIP: 'None'
-    ports: [
-      {
-        port: port
-      }
-    ]
-    selector: {
-      app: name
-    }
-  }
-}
-
-output name string = '${name}.${namespace}.svc.cluster.local'
-output dbName string = name
-output port int = port
-
-output connectionString string = 'mongodb://${name}.${namespace}.svc.cluster.local:${port}/${name}?authSource=admin'


### PR DESCRIPTION
We had a regression in 0.16 due to samples and docs not matching in the tutorial. The sample validation in radius was passing, but because the docs are never validated, we missed this.

This PR makes the content the same between docs and samples. Long term, we need a way to ensure that samples and docs use the same source of truth. It is unacceptable to be giving content to users that isn't tested.