### PR TITLE
Fix env init and add failure notification

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,7 +60,7 @@ jobs:
           rad env create default
           rad env switch default
       - name: Deploy demo tutorial
-        run:  rad deploy ./demo/appTEST.bicep --application demo
+        run:  rad deploy ./demo/app.bicep --application demo
       - name: Delete demo tutorial
         run:  rad app delete demo -y
       - name: Deploy Dapr quickstart


### PR DESCRIPTION
This PR:

1. Switches `rad env init kubernetes` to `rad install` and `rad env create`
2. Adds a step to open a GitHub Issue in the samples repo if the test fails
3. Adds a cron job to run this test at 7:45 AM PT
   - Note that this won't start running until the 0.19 release, when the `v0.19` branch is created and set as default branch. See [the docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule) for information.
