### PR TITLE
Updating username logic to allow empty strings

### DIFF
--- a/demo/src/db/repository.ts
+++ b/demo/src/db/repository.ts
@@ -42,10 +42,12 @@ export function createFactory(): RepositoryFactory {
       if (connection.port === "6380") {
         scheme = "rediss"
       }
-  
+      console.log("Made it to CONNECTION_REDIS_HOST conditional");
+
       let usernamePass = "";
       if (connection.username !== null && connection.password && connection.password !== "") {
         usernamePass = `${connection.username}:${connection.password}@`
+        console.log("Made it to username conditional");
       }
   
       const url = `${scheme}://${usernamePass}${connection.host}:${connection.port}`


### PR DESCRIPTION
## Description

Currently the `username` conditional requires a `username` to not be empty or null, should allow for empty strings for Azure Redis Cache deployments.