### PR TITLE
Allow demo app to use Redis connection strings

### DIFF
--- a/demo/src/db/repository.ts
+++ b/demo/src/db/repository.ts
@@ -27,6 +27,11 @@ export function createFactory(): RepositoryFactory {
       console.log("Using MongoDB: found connection string in environment variable CONNECTION_MONGODB_CONNECTIONSTRING");
       return new MongoFactory(process.env.CONNECTION_MONGODB_CONNECTIONSTRING);
     }
+    
+    if (process.env.CONNECTION_REDIS_CONNECTIONSTRING) {
+        console.log("Using Redis: found connection string in environment variable CONNECTION_REDIS_CONNECTIONSTRING");
+        return new RedisFactory(process.env.CONNECTION_REDIS_CONNECTIONSTRING)
+    }
 
     if (process.env.CONNECTION_REDIS_HOST) {
       console.log("Using Redis: found hostname in environment variable CONNECTION_REDIS_HOST");


### PR DESCRIPTION
Today we use scheme of `rediss` when the port is set to 6380. This isn't the case with MemoryDB, where TLS Redis is set on port 6379.

This PR adds a check for a Redis connection string, and uses that instead of building one when creating the Redis driver.

That way in our MemoryDB recipe we can set both hostname and port, and then set a connection string with the rediss scheme.