### PR TITLE
Move cluster creation to post-create

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"image": "mcr.microsoft.com/devcontainers/universal:linux",
 	"workspaceFolder": "/workspaces/samples",
 	"onCreateCommand": "bash ./.devcontainer/on-create.sh",
+	"postCreateCommand": "bash ./.devcontainer/post-create.sh",
 	"runArgs": [
 	  "--privileged",
 	  "--init"

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -1,14 +1,5 @@
 #!/bin/sh
 
-## Create a k3d cluster
-k3d cluster delete
-k3d cluster create -p '8081:80@loadbalancer' --k3s-arg '--disable=traefik@server:0'
-
-## Install Dapr and init
-wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash
-dapr uninstall # clean if needed
-dapr init -k
-
 ## Install rad CLI
 CURRENT_BRANCH=$(git branch --show-current)
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+## Create a k3d cluster
+k3d cluster delete
+k3d cluster create -p '8081:80@loadbalancer' --k3s-arg '--disable=traefik@server:0'
+
+## Install Dapr and init
+wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash
+dapr uninstall # clean if needed
+dapr init -k


### PR DESCRIPTION
During pre-builds the Docker daemon is no longer available. This PR moves cluster creation and Dapr installation to post-create after the user lands in the Codespace.