### PR TITLE
Fix edge version download

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -191,8 +191,8 @@ jobs:
               echo "Downloading rad CLI version ${{ inputs.version }}"
               wget -q "${{ env.RAD_CLI_URL }}" -O - | /bin/bash -s ${{ inputs.version }}
             else
-              echo "Downloading edge rad CLI"
-              wget -q "${{ env.RAD_CLI_URL }}" -O - | /bin/bash -s edge
+              echo "Downloading latest rad CLI"
+              wget -q "${{ env.RAD_CLI_URL }}" -O - | /bin/bash
             fi
 
             if [ $? -eq 0 ]; then


### PR DESCRIPTION
This PR fixes the download of the rad CLI as edge cannot be installed via the installation script

Once the edge CLI is pushed to GHCR as an OCI artifact we can update this script to pull that instead. But for now the latest rad CLI will unblock test runs