### PR TITLE
Added a condition to allow Docker to fully setup during post-create

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,8 +1,13 @@
 #!/bin/sh
 
 ## Create a k3d cluster
-k3d cluster delete
-k3d cluster create -p '8081:80@loadbalancer' --k3s-arg '--disable=traefik@server:0'
+while (! kubectl cluster-info ); do
+  # Docker takes a few seconds to initialize
+  echo "Waiting for Docker to launch..."
+  k3d cluster delete
+  k3d cluster create -p '8081:80@loadbalancer' --k3s-arg '--disable=traefik@server:0'
+  sleep 1
+done
 
 ## Install Dapr and init
 wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash


### PR DESCRIPTION
## Description
Fixes post-create error `Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?` during K8 cluster creation