### PR TITLE
Update container build to only push on merges

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,9 +20,7 @@ env:
   VERSION: ${{ github.event.pull_request.number || 'latest' }}
   # Use ghcr.io/radius-project/dev for PR build. Otherwise, use ghcr.io/radius-project.
   CONTAINER_REGISTRY: ${{ github.event.pull_request.number && 'ghcr.io/radius-project/dev' || 'ghcr.io/radius-project' }}
-  # Set to true to push images to registry.
-  PUSH_IMAGE: true
-
+ 
 jobs:
   build-ghcr:
     name: Build and push sample images to GHCR
@@ -48,6 +46,15 @@ jobs:
           - directory: samples/volumes/
             image: samples/volumes
     steps:
+      - name: Evaluate push
+        id: eval_push
+        run: |
+            if [[ "${{ github.event_name }}" == "push" ]]; then
+              PUSH_IMAGE='true'
+            else
+              PUSH_IMAGE='false'
+            fi
+            echo "PUSH_IMAGE=${PUSH_IMAGE}" >> $GITHUB_OUTPUT
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Login to GitHub Container Registry
@@ -56,10 +63,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - run: echo "event name is:" ${{ github.event_name }} 
+      - run: echo "event type is:" ${{ github.event.action }} 
       - name: Build and push ${{ matrix.image }}
         uses: docker/build-push-action@v4
         with:
           context: ./${{ matrix.directory }}
-          if: github.event_name == 'push'
-          push: ${{ env.PUSH_IMAGE }}
+          push: ${{ fromJSON(steps.eval_push.outputs.PUSH_IMAGE) }}
           tags: ${{ env.CONTAINER_REGISTRY }}/${{ matrix.image }}:${{ env.VERSION }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,5 +60,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: ./${{ matrix.directory }}
+                   context: ./${{ matrix.directory }}
+          if: github.event_name == 'push'
           push: ${{ env.PUSH_IMAGE }}
           tags: ${{ env.CONTAINER_REGISTRY }}/${{ matrix.image }}:${{ env.VERSION }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,6 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: ./${{ matrix.directory }}
-                   context: ./${{ matrix.directory }}
           if: github.event_name == 'push'
           push: ${{ env.PUSH_IMAGE }}
           tags: ${{ env.CONTAINER_REGISTRY }}/${{ matrix.image }}:${{ env.VERSION }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,18 +46,8 @@ jobs:
           - directory: samples/volumes/
             image: samples/volumes
     steps:
-      - name: Evaluate push
-        id: eval_push
-        run: |
-            if [[ "${{ github.event_name }}" == "push" ]]; then
-              PUSH_IMAGE='true'
-            else
-              PUSH_IMAGE='false'
-            fi
-            echo "PUSH_IMAGE=${PUSH_IMAGE}" >> $GITHUB_OUTPUT
       - name: Checkout code
         uses: actions/checkout@v4
-      # Using fromJSON to convert string to boolean. Ref. https://github.com/actions/runner/issues/1483
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -69,5 +59,4 @@ jobs:
         with:
           context: ./${{ matrix.directory }}
           push: ${{ github.event_name == 'push' && true || false }}
-          # push: ${{ fromJSON(steps.eval_push.outputs.PUSH_IMAGE) }}
           tags: ${{ env.CONTAINER_REGISTRY }}/${{ matrix.image }}:${{ env.VERSION }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,5 +68,6 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: ./${{ matrix.directory }}
-          push: ${{ fromJSON(steps.eval_push.outputs.PUSH_IMAGE) }}
+          push: ${{ github.event_name == 'push' && true || false }}
+          # push: ${{ fromJSON(steps.eval_push.outputs.PUSH_IMAGE) }}
           tags: ${{ env.CONTAINER_REGISTRY }}/${{ matrix.image }}:${{ env.VERSION }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,8 +63,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - run: echo "event name is:" ${{ github.event_name }} 
-      - run: echo "event type is:" ${{ github.event.action }} 
       - name: Build and push ${{ matrix.image }}
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,6 +57,7 @@ jobs:
             echo "PUSH_IMAGE=${PUSH_IMAGE}" >> $GITHUB_OUTPUT
       - name: Checkout code
         uses: actions/checkout@v4
+      # Using fromJSON to convert string to boolean. Ref. https://github.com/actions/runner/issues/1483
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -38,7 +38,7 @@ jobs:
     name: Sync issue to Azure DevOps
     runs-on: ubuntu-latest
     steps:
-      - uses: danhellem/github-actions-issue-to-work-item@v2.0
+      - uses: danhellem/github-actions-issue-to-work-item@v2.1
         env:
           ado_token: "${{ secrets.ADO_AOCTO_BOT_TOKEN }}"
           github_token: "${{ secrets.GH_RAD_CI_BOT_PAT }}"
@@ -46,6 +46,7 @@ jobs:
           ado_project: "Incubations"
           ado_area_path: "Incubations\\Radius"
           ado_iteration_path: "Incubations\\Radius"
+          ado_wit: "GitHub Issue"
           ado_new_state: "New"
           ado_active_state: "Active"
           ado_close_state: "Closed"

--- a/.github/workflows/validate-bicep.yaml
+++ b/.github/workflows/validate-bicep.yaml
@@ -31,12 +31,6 @@ jobs:
     steps:
     - name: Check out repo
       uses: actions/checkout@v2
-    - name: az CLI login
-      run: |
-        az login --service-principal \
-          --username ${{ secrets.AZURE_SP_TESTS_APPID }} \
-          --password ${{ secrets.AZURE_SP_TESTS_PASSWORD }} \
-          --tenant ${{ secrets.AZURE_SP_TESTS_TENANTID }}
     - name: Parse release version and set environment variables
       run: python ./.github/scripts/get_docs_version.py
     - name: Download rad-bicep


### PR DESCRIPTION
Enable PR from forks:
- remove az login from validate-bicep yaml since this is no longer required
- push to GHCR only when github action is a push. For PRs from forks, the action_name is pull_request. 