### PR TITLE
Dapr tutorial port and routes fixes

### DIFF
--- a/samples/dapr/dapr-azure.bicep
+++ b/samples/dapr/dapr-azure.bicep
@@ -45,11 +45,11 @@ resource frontend 'Applications.Core/containers@2023-10-01-preview' = {
       image: 'ghcr.io/radius-project/samples/dapr-frontend:latest'
       env: {
         CONNECTION_BACKEND_APPID: backend.name
+        ASPNETCORE_URLS: 'http://*:8080'
       }
       ports: {
         ui: {
-          containerPort: 80
-          provides: frontendRoute.id
+          containerPort: 8080
         }
       }
     }
@@ -57,26 +57,6 @@ resource frontend 'Applications.Core/containers@2023-10-01-preview' = {
       {
         kind: 'daprSidecar'
         appId: 'frontend'
-      }
-    ]
-  }
-}
-
-resource frontendRoute 'Applications.Core/httpRoutes@2023-10-01-preview' = {
-  name: 'frontend-route'
-  properties: {
-    application: app.id
-  }
-}
-
-resource gateway 'Applications.Core/gateways@2023-10-01-preview' = {
-  name: 'gateway'
-  properties: {
-    application: app.id
-    routes: [
-      {
-        path: '/'
-        destination: frontendRoute.id
       }
     ]
   }

--- a/samples/dapr/dapr.bicep
+++ b/samples/dapr/dapr.bicep
@@ -48,11 +48,11 @@ resource frontend 'Applications.Core/containers@2023-10-01-preview' = {
       image: 'ghcr.io/radius-project/samples/dapr-frontend:latest'
       env: {
         CONNECTION_BACKEND_APPID: backend.name
+        ASPNETCORE_URLS: 'http://*:8080'
       }
       ports: {
         ui: {
-          containerPort: 80
-          provides: frontendRoute.id
+          containerPort: 8080
         }
       }
     }
@@ -60,26 +60,6 @@ resource frontend 'Applications.Core/containers@2023-10-01-preview' = {
       {
         kind: 'daprSidecar'
         appId: 'frontend'
-      }
-    ]
-  }
-}
-
-resource frontendRoute 'Applications.Core/httpRoutes@2023-10-01-preview' = {
-  name: 'frontend-route'
-  properties: {
-    application: app.id
-  }
-}
-
-resource gateway 'Applications.Core/gateways@2023-10-01-preview' = {
-  name: 'gateway'
-  properties: {
-    application: app.id
-    routes: [
-      {
-        path: '/'
-        destination: frontendRoute.id
       }
     ]
   }


### PR DESCRIPTION
1. change frontend port to use `8080` instead of the default `80` that the .NET app uses, since port `80` is problematic for `localhost` testing.
1. remove the routes and gateways configs since those are no longer needed