### PR TITLE
Fix Dapr sample in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -235,6 +235,7 @@ jobs:
         run: |
           namespace="${{ matrix.env }}-${{ matrix.app }}"
           label="radapp.io/application=${{ matrix.app }}"
+          kubectl get deployments -A
           kubectl rollout status deployment default-dapr -n $namespace --timeout=90s
           kubectl wait --for=condition=Ready pod -l $label -n $namespace --timeout=5m
       - name: DEBUG

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -235,16 +235,7 @@ jobs:
         run: |
           namespace="${{ matrix.env }}-${{ matrix.app }}"
           label="radapp.io/application=${{ matrix.app }}"
-          kubectl get deployments -A
           kubectl rollout status deployment -l $label -n $namespace --timeout=90s
-      - name: DEBUG
-        if: always() && steps.gen-id.outputs.RUN_TEST == 'true'
-        run: |
-          namespace="${{ matrix.env }}-${{ matrix.app }}"
-          label="radapp.io/application=${{ matrix.app }}"
-          kubectl get pods -A
-          kubectl get pods -l $label -n $namespace
-          kubectl describe pods -l $label -n $namespace
       - name: Run Playwright Test
         if: steps.gen-id.outputs.RUN_TEST == 'true' && matrix.uiTestFile != ''
         id: run-playwright-test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -236,7 +236,7 @@ jobs:
           namespace="${{ matrix.env }}-${{ matrix.app }}"
           label="radapp.io/application=${{ matrix.app }}"
           kubectl get deployments -A
-          kubectl rollout status deployment default-dapr -n $namespace --timeout=90s
+          kubectl rollout status deployment -l $label -n $namespace --timeout=90s
           kubectl wait --for=condition=Ready pod -l $label -n $namespace --timeout=5m
       - name: DEBUG
         if: always() && steps.gen-id.outputs.RUN_TEST == 'true'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -236,6 +236,14 @@ jobs:
           namespace="${{ matrix.env }}-${{ matrix.app }}"
           label="radapp.io/application=${{ matrix.app }}"
           kubectl wait --for=condition=Ready pod -l $label -n $namespace --timeout=5m
+      - name: DEBUG
+        if: always() && steps.gen-id.outputs.RUN_TEST == 'true'
+        run: |
+          namespace="${{ matrix.env }}-${{ matrix.app }}"
+          label="radapp.io/application=${{ matrix.app }}"
+          kubectl get pods -A
+          kubectl get pods -l $label -n $namespace
+          kubectl describe pods -l $label -n $namespace
       - name: Run Playwright Test
         if: steps.gen-id.outputs.RUN_TEST == 'true' && matrix.uiTestFile != ''
         id: run-playwright-test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -235,6 +235,7 @@ jobs:
         run: |
           namespace="${{ matrix.env }}-${{ matrix.app }}"
           label="radapp.io/application=${{ matrix.app }}"
+          kubectl rollout status deployment default-dapr -n $namespace --timeout=90s
           kubectl wait --for=condition=Ready pod -l $label -n $namespace --timeout=5m
       - name: DEBUG
         if: always() && steps.gen-id.outputs.RUN_TEST == 'true'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -237,7 +237,6 @@ jobs:
           label="radapp.io/application=${{ matrix.app }}"
           kubectl get deployments -A
           kubectl rollout status deployment -l $label -n $namespace --timeout=90s
-          kubectl wait --for=condition=Ready pod -l $label -n $namespace --timeout=5m
       - name: DEBUG
         if: always() && steps.gen-id.outputs.RUN_TEST == 'true'
         run: |


### PR DESCRIPTION
Fixes failing Dapr sample in CI - the previous check was waiting for pods to be ready, but some of them were terminated or terminating, which caused the check to timeout. Now it will check for the deployment rollout status.

Fixes: https://github.com/radius-project/samples/issues/829