### PR TITLE
Force delete Radius application, EKS Cluster, and AWS resources on failed workflow run

### DIFF
--- a/.github/scripts/delete-aws-resources.sh
+++ b/.github/scripts/delete-aws-resources.sh
@@ -17,8 +17,8 @@
 # ------------------------------------------------------------
 
 
-APP_NAME=$1
-APP_LABEL='RadiusApplication'
+APP_ID=$1
+APP_LABEL='radapp.io/application'
 RESOURCE_TYPES='AWS::RDS::DBInstance,AWS::RDS::DBSubnetGroup,AWS::MemoryDB::Cluster,AWS::MemoryDB::SubnetGroup'
 
 # File to store the list of deleted resources
@@ -45,7 +45,7 @@ function delete_aws_resources() {
         do
           key=$(jq -r '.Key' <<< "$tag")
           value=$(jq -r '.Value' <<< "$tag")
-          if [[ "$key" == "$APP_LABEL" && "$value" == "$APP_NAME" ]]
+          if [[ "$key" == "$APP_LABEL" && "$value" == "$APP_ID" ]]
           then
             echo "Deleting resource of type: $resource_type with identifier: $identifier"
             echo "$identifier\n" >> $DELETED_RESOURCES_FILE

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -289,7 +289,7 @@ jobs:
         run: gh issue create --title "Samples deployment failed for ${{ matrix.app }}" --body "Test failed on ${{ github.repository }}. See [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details." --repo ${{ github.repository }}
       # Cleanup
       - name: Delete app
-        if: steps.gen-id.outputs.RUN_TEST == 'true'
+        if: always() && steps.gen-id.outputs.RUN_TEST == 'true'
         run: |
           rad app delete ${{ matrix.app }} -y
       - name: Delete Azure resource group
@@ -305,7 +305,7 @@ jobs:
         if: always() && steps.gen-id.outputs.RUN_TEST == 'true' && matrix.credential == 'aws'
         run: |
           # Delete all AWS resources created by the test
-          ./.github/scripts/delete-aws-resources.sh ${{ matrix.app }}
+          ./.github/scripts/delete-aws-resources.sh '/planes/radius/local/resourcegroups/default/providers/Applications.Core/applications/${{ matrix.app }}'
       - name: Delete EKS Cluster
         if: always() && steps.gen-id.outputs.RUN_TEST == 'true' && matrix.credential == 'aws'
         run: |
@@ -313,4 +313,4 @@ jobs:
           rad uninstall kubernetes
           # Delete EKS cluster
           echo "Deleting EKS cluster: ${{ steps.gen-id.outputs.TEST_EKS_CLUSTER_NAME }}"
-          eksctl delete cluster --name ${{ steps.gen-id.outputs.TEST_EKS_CLUSTER_NAME }} --region ${{ env.AWS_REGION }} --wait
+          eksctl delete cluster --name ${{ steps.gen-id.outputs.TEST_EKS_CLUSTER_NAME }} --region ${{ env.AWS_REGION }} --wait --force


### PR DESCRIPTION
* update delete-aws-resources for new recipe related changes
* force delete EKS cluster
* always delete radius app

Fixes: https://github.com/radius-project/samples/issues/827