### PR TITLE
Add test-failure Issue Label to Workflow Failures

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -286,7 +286,7 @@ jobs:
           if-no-files-found: error
       - name: Create GitHub issue on failure
         if: failure() && github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch'
-        run: gh issue create --title "Samples deployment failed for ${{ matrix.app }}" --body "Test failed on ${{ github.repository }}. See [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details." --repo ${{ github.repository }}
+        run: gh issue create --title "Samples deployment failed for ${{ matrix.app }}" --body "Test failed on ${{ github.repository }}. See [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details." --repo ${{ github.repository }} --label test-failure
       # Cleanup
       - name: Delete app
         if: always() && steps.gen-id.outputs.RUN_TEST == 'true'


### PR DESCRIPTION
Add test-failure label to the issues opened on test samples workflow failure. This was added in https://github.com/radius-project/samples/pull/858 but was only merged into 0.27 branch.

Not including the label for "bug" here since a failure in this workflow can be caused by dependencies in addition to bugs in Radius, so if the issue is indeed a bug or not needs to be decided after initial investigation.