### PR TITLE
Update workflow to create issue upon failures only for 'scheduled run'

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -285,7 +285,7 @@ jobs:
           retention-days: 30
           if-no-files-found: error
       - name: Create GitHub issue on failure
-        if: failure() && github.event_name != 'pull_request' && github.event_name != 'workflow_dispatch'
+        if: failure() && github.event_name == 'schedule'
         run: gh issue create --title "Samples deployment failed for ${{ matrix.app }}" --body "Test failed on ${{ github.repository }}. See [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details." --repo ${{ github.repository }} --label test-failure
       # Cleanup
       - name: Delete app


### PR DESCRIPTION
Attempt to fix issue described in https://github.com/radius-project/samples/issues/896 where a merge into a branch followed by a failed test run is raising Alerts in Teams Channel incorrectly. 
The PR updates condition to github.event_name == 'schedule' for a scheduled event when creating an issue for a failed test run.
