### PR TITLE
Fix local build/run for demo container

### DIFF
--- a/samples/demo/Dockerfile
+++ b/samples/demo/Dockerfile
@@ -14,7 +14,6 @@ WORKDIR /usr/src/app
 
 COPY --from=BUILD /usr/src/app/dist ./dist
 COPY --from=BUILD /usr/src/app/node_modules ./node_modules
-COPY --from=BUILD /usr/src/app/client/build/. ./dist/www/
 
 EXPOSE 3000
 ENV PORT=3000

--- a/samples/demo/build-client.js
+++ b/samples/demo/build-client.js
@@ -1,2 +1,3 @@
 const opts = { stdio: 'inherit', cwd: 'client', shell: true };
 require('child_process').execSync('npm run build', opts);
+require('fs').cpSync('client/build', 'dist/www', { recursive: true });


### PR DESCRIPTION
For some reason the copy step for frontend assets is in the Dockerfile instead of the build script. This meant that the local build didn't work. Moving this step into the build and removing it from the docker file should address the issue.