### PR TITLE
Update images for guestbook sample app

### DIFF
--- a/samples/kubernetes/guestbook/deploy/frontend-deployment.yaml
+++ b/samples/kubernetes/guestbook/deploy/frontend-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: ghcr.io/radius-project/dev/gb-frontend:v4
+        image: ghcr.io/radius-project/gb-frontend:v4  
         resources:
           requests:
             cpu: 100m

--- a/samples/kubernetes/guestbook/deploy/frontend-deployment.yaml
+++ b/samples/kubernetes/guestbook/deploy/frontend-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: ghcr.io/radius-project/gb-frontend:v4  
+        image: ghcr.io/radius-project/samples/gb-frontend:v4
         resources:
           requests:
             cpu: 100m

--- a/samples/kubernetes/guestbook/deploy/frontend-deployment.yaml
+++ b/samples/kubernetes/guestbook/deploy/frontend-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google-samples/gb-frontend:v4
+        image: ghcr.io/radius-project/dev/gb-frontend:v4
         resources:
           requests:
             cpu: 100m

--- a/samples/kubernetes/guestbook/deploy/redis-replica-deployment.yaml
+++ b/samples/kubernetes/guestbook/deploy/redis-replica-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: slave
-        image: ghcr.io/radius-project/dev/gb-redisreplica:v1
+        image: ghcr.io/radius-project/gb-redisreplica:v1 
         resources:
           requests:
             cpu: 100m

--- a/samples/kubernetes/guestbook/deploy/redis-replica-deployment.yaml
+++ b/samples/kubernetes/guestbook/deploy/redis-replica-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: slave
-        image: gcr.io/google_samples/gb-redisslave:v1
+        image: ghcr.io/radius-project/dev/gb-redisreplica:v1
         resources:
           requests:
             cpu: 100m

--- a/samples/kubernetes/guestbook/deploy/redis-replica-deployment.yaml
+++ b/samples/kubernetes/guestbook/deploy/redis-replica-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: slave
-        image: ghcr.io/radius-project/gb-redisreplica:v1 
+        image: ghcr.io/radius-project/samples/gb-redisreplica:v1 
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
This is to address https://github.com/radius-project/samples/issues/914 where a broken dependency on an image in the Google container registry is broken. 

We fix the issue by downloading and pushing a copy of the required images into the Radius container registry so that we no longer have a dependency on Google's container registry:

- gcr.io/google_samples/gb-redisslave:v1 --> ghcr.io/radius-project/gb-redisreplica:v1 
- gcr.io/google-samples/gb-frontend:v4 --> ghcr.io/radius-project/gb-frontend:v4  

Fixes: https://github.com/radius-project/samples/issues/914