### PR TITLE
Fix GitHub branch switch bug on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,5 +45,5 @@ jobs:
           --method PATCH \
           -H "Accept: application/vnd.github+json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          /repos/radius-project/samples \
+          repos/radius-project/samples \
           -f default_branch='v${{ steps.parse_release_channel.outputs.channel }}'


### PR DESCRIPTION
relevant failure: https://github.com/radius-project/samples/actions/runs/7749953189/job/21135401707

https://stackoverflow.com/questions/73011381/why-reading-pull-request-data-using-github-cli-api-causes-gh-not-found-http-4

Fixes: https://github.com/radius-project/docs/issues/1033 