### PR TITLE
Removing the run of the AKS workflow on PRs

### DIFF
--- a/.github/workflows/test-aks.yaml
+++ b/.github/workflows/test-aks.yaml
@@ -15,11 +15,6 @@ on:
     paths:
       - "samples/**"
       - ".github/workflows/**"
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches:
-      - v*.*
-      - edge
   schedule: # Run every 2 hours
     - cron: "0 */2 * * *"
 env:


### PR DESCRIPTION
This PR is to remove the section that enables the run of test-aks in PRs. We don't need to run that action in PRs.