### PR TITLE
Changing the place of page.reload in the tests

### DIFF
--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -47,7 +47,7 @@ export default defineConfig({
       use: { ...devices["Desktop Safari"] },
     },
   ],
-  timeout: 5 * 60 * 1000,
+  timeout: 1 * 60 * 1000,
   expect: {
     timeout: 30 * 1000,
   },

--- a/playwright/tests/eshop/eshop.app.spec.ts
+++ b/playwright/tests/eshop/eshop.app.spec.ts
@@ -92,6 +92,12 @@ test("eShop on Containers App Basic UI and Functionality Checks", async ({
 
   while (attempts < maxAttempts) {
     try {
+      // If the item is not found in the first attempt,
+      // reload the page to trigger the API call again.
+      if (attempts > 0) {
+        await page.reload();
+      }
+
       await page.waitForSelector(firstItemSelector);
       firstItem = page.locator(firstItemSelector);
       await expect(firstItem).toBeVisible();
@@ -102,7 +108,6 @@ test("eShop on Containers App Basic UI and Functionality Checks", async ({
     } catch (error) {
       // If the item is not found within 5 seconds, an error will be thrown here, then the page will be reloaded
       console.error("Item not found:", error);
-      await page.reload();
       attempts++;
     }
   }


### PR DESCRIPTION
* Changing the place of `page.reload` in the tests.
* Decreasing the UI test timeout to 1 minute.