### PR TITLE
Add pr template for samples repo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+# Description
+
+_Please explain the changes you've made._
+
+## Type of change
+
+<!--
+
+Please select **one** of the following options that describes your change and delete the others. Clearly identifying the type of change you are making will help us review your PR faster, and is used in authoring release notes.
+
+If you are making a bug fix or functionality change to Radius and do not have an associated issue link please create one now. 
+
+-->
+
+- This pull request fixes a bug in Radius samples and has an approved issue (issue link required).
+- This pull request adds or changes features of Radius samples and has an approved issue (issue link required).
+- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius samples (issue link optional).
+
+<!--
+
+Please update the following to link the associated issue. This is required for some kinds of changes (see above).
+
+-->
+
+Fixes: #issue_number


### PR DESCRIPTION
# Description

Adds a PR template, based on the PR template in the radius repo.

## Type of change

- This pull request is a minor refactor, code cleanup, test improvement, or other maintenance task and doesn't change the functionality of Radius samples (issue link optional).

Fixes: N/A