### PR TITLE
Update validate bicep workflow 

### DIFF
--- a/.github/scripts/validate_bicep.py
+++ b/.github/scripts/validate_bicep.py
@@ -28,6 +28,7 @@ print(f"Using Bicep binary: {bicep_executable}", flush=True)
 
 files = []
 failures = []
+warnings = []
 
 # Walk the directory tree and find all .bicep files
 for root, _, filenames in os.walk("."):
@@ -46,12 +47,11 @@ def validate_file(f):
     stderr = result.stderr.decode("utf-8")
     exitcode = result.returncode
   
-    warning_prefix = "WARNING: The following experimental Bicep features"
-    if stderr.startswith(warning_prefix) and "Error" not in stderr:
-        stderr = ""
-        exitcode = 0
+    if "Warning" in stderr:
+        warnings.append(f)
+        print(stderr, flush=True)
 
-    if exitcode != 0:
+    if exitcode != 0 or "Error" in stderr:
         failures.append(f)
         print(stderr, flush=True)
 
@@ -61,5 +61,8 @@ concurrent.futures.wait(futures)
 
 for f in failures:
     print(f"Failed: {f}", flush=True)
+
+for f in warnings:
+    print(f"Warning: {f}", flush=True)
 
 exit(len(failures))

--- a/.github/workflows/validate-bicep.yaml
+++ b/.github/workflows/validate-bicep.yaml
@@ -29,12 +29,12 @@ jobs:
     name: Validate Bicep Code
     runs-on: ubuntu-latest
     steps:
+    - name: Check out repo
+      uses: actions/checkout@v4
     - name: Setup and verify bicep CLI
       run: |
         curl -Lo rad-bicep https://github.com/Azure/bicep/releases/latest/download/bicep-linux-x64
         chmod +x ./rad-bicep
         ./rad-bicep --version
-    - name: Check out repo
-      uses: actions/checkout@v4
     - name: Verify Bicep files
       run: python ./.github/scripts/validate_bicep.py

--- a/samples/eshop-dapr/infra/dapr-state-store.bicep
+++ b/samples/eshop-dapr/infra/dapr-state-store.bicep
@@ -91,7 +91,7 @@ resource daprStateStore 'Applications.Dapr/stateStores@2023-10-01-preview' = {
     version: 'v1'
     metadata: {
       url: cosmosAccount.properties.documentEndpoint
-      masterKey: listKeys(cosmosAccount.id, cosmosAccount.apiVersion).primaryMasterKey
+      masterKey: cosmosAccount.listKeys().primaryMasterKey
       database: cosmosDbName
       collection: cosmosDbCollectionName
       actorStateStore: 'true'

--- a/samples/eshop/infra/infra.bicep
+++ b/samples/eshop/infra/infra.bicep
@@ -113,4 +113,5 @@ output rabbitmq string = rabbitmq.name
 output servicebus string = servicebus.name
 
 @description('Event Bus connection string')
+#disable-next-line outputs-should-not-contain-secrets
 output eventBusConnectionString string = (AZURESERVICEBUSENABLED == 'True') ? servicebus.listSecrets().connectionString : rabbitmq.properties.host


### PR DESCRIPTION
This updates the workflow to print out warnings. Earlier we were only checking for errors so we wouldn't print on warnings if they came up. This logs warnings but doesn't fail. There's some minor updates to the bicep files to address these warnings as well 