### PR TITLE
Set dev container bicep extension and remove workspace path

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,6 @@
 {
 	"name": "Radius Dev Container",
 	"image": "mcr.microsoft.com/devcontainers/universal:linux",
-	"workspaceFolder": "/workspaces/samples",
 	"onCreateCommand": "bash ./.devcontainer/on-create.sh",
 	"postCreateCommand": "bash ./.devcontainer/post-create.sh",
 	"runArgs": [
@@ -27,7 +26,7 @@
 			"ms-python.python",
 			"dunn.redis",
 			"GitHub.copilot",
-			"ms-azuretools.rad-vscode-bicep"
+			"ms-azuretools.vscode-bicep"
 		]
 	  }
 	},


### PR DESCRIPTION
# Description

Two minor changes to the dev container:

- Sets the VS Code Bicep extension (removing the Radius Bicep extension). As of version 0.37 of Radius the Radius Bicep extension is no longer needed.
- Removes the hard coded `workspaceFolder`. This setting is automatically set by the dev container. The hard coded path causes a container build error when the samples repo is cloned to a folder named something other than `samples`. For example, if someone clones the repo to a folder named `radius-samples`, the container build will fail because it is expecting the workspace folder to be named `samples`.

This is a minor change. No GitHub issue is linked to this PR.
