### PR TITLE
Fix samples test issue with release channel version

### DIFF
--- a/.github/scripts/install-radius.sh
+++ b/.github/scripts/install-radius.sh
@@ -1,12 +1,6 @@
+#!/bin/bash
+
 # ------------------------------------------------------------
-# Copyright 2023 The Radius Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +10,8 @@
 
 set -xe
 
+# VERSION is the version of the rad CLI to download
+# e.g. 0.1, 0.1.0, 0.1.0-rc1, edge
 VERSION=$1
 RAD_CLI_URL=https://raw.githubusercontent.com/radius-project/radius/main/deploy/install.sh
 RAD_CLI_EDGE_URL=ghcr.io/radius-project/rad/linux-amd64:latest
@@ -26,8 +22,25 @@ if [[ $VERSION == "edge" ]]; then
     chmod +x ./rad
     mv ./rad /usr/local/bin/rad
 elif [[ -n $VERSION ]]; then
-    echo Downloading rad CLI version $VERSION
-    wget -q $RAD_CLI_URL -O - | /bin/bash -s $VERSION
+    RADIUS_VERSION=$VERSION
+    # if version is a channel, e.g. 0.1
+    if [[ "$VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+        echo "Querying the most recent version of the specified channel: $VERSION"
+        RADIUS_VERSION=$(curl -L -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/radius-project/radius/releases | jq -r  '.[] | .tag_name | select(startswith("v'$VERSION'"))' | head -n 1)
+        echo "Found version $RADIUS_VERSION"
+        if [[ -z "$RADIUS_VERSION" ]]; then
+            echo "No releases found for channel $VERSION"
+            exit 1
+        fi
+    else
+        echo "The string does not match the pattern [anynumber].[anynumber]"
+    fi
+
+    # remove the 'v' prefix
+    RADIUS_VERSION=$(echo $RADIUS_VERSION | cut -d "v" -f 2)
+
+    echo Downloading rad CLI version $RADIUS_VERSION
+    wget -q $RAD_CLI_URL -O - | /bin/bash -s $RADIUS_VERSION
 else
     echo Downloading latest rad CLI
     wget -q $RAD_CLI_URL -O - | /bin/bash

--- a/.github/scripts/install-radius.sh
+++ b/.github/scripts/install-radius.sh
@@ -1,6 +1,12 @@
-#!/bin/bash
-
 # ------------------------------------------------------------
+# Copyright 2023 The Radius Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
In the `test.yaml` scheduled runs, pulling the rad CLI by channel is not supported: https://github.com/radius-project/samples/actions/runs/10940522467/job/30383750893

this PR adds the ability to specify channel version to the `install-radius.sh` script.