### PR TITLE
Change 4-core runner to use ubuntu-latest

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
             images: samples/demo
             directories: samples/demo/
           - name: dapr
-            os: ubuntu-latest-m
+            os: ubuntu-latest
             runOnPullRequest: true
             app: dapr
             env: default
@@ -66,7 +66,7 @@ jobs:
             images: samples/volumes
             directories: samples/volumes/
           - name: eshop-containers
-            os: ubuntu-latest-m
+            os: ubuntu-latest
             runOnPullRequest: true
             app: eshop
             env: default
@@ -74,7 +74,7 @@ jobs:
             uiTestFile: tests/eshop/eshop.app.spec.ts
             enableDapr: false
           - name: eshop-azure
-            os: ubuntu-latest-m
+            os: ubuntu-latest
             runOnPullRequest: false
             app: eshop
             env: azure
@@ -83,7 +83,7 @@ jobs:
             credential: azure
             enableDapr: false
           - name: eshop-aws
-            os: ubuntu-latest-m
+            os: ubuntu-latest
             runOnPullRequest: false
             app: eshop
             env: aws


### PR DESCRIPTION
Heya! Friendly neighborhood CNCF staffer here. The ubuntu-latest runner is already a 4-core runner, so using a hosted 4-core runner is unnecessary (and actually costs money). This PR just swaps any 4-core hosted runners to use ubuntu-latest. There should be zero change or impact, functionally this is a SKU change.

Please reach out to me in the CNCF/K8s slack(s) (jeefy) or via email (jsica@linuxfoundation.org) with any questions. 