### PR TITLE
Fix release-samples.sh

### DIFF
--- a/.github/scripts/release-samples.sh
+++ b/.github/scripts/release-samples.sh
@@ -52,7 +52,7 @@ mv bicepconfig_updated.json bicepconfig.json
 
 # Push changes to GitHub
 git add --all
-git commit -m "Update samples for ${VERSION}"
+git commit -m "Update samples for ${CHANNEL_VERSION}"
 git push origin "${CHANNEL_VERSION}"
 
 popd


### PR DESCRIPTION
Release script was updated recently https://github.com/radius-project/samples/pull/1790, and is failing, likely due to the wrong parameter name. Trying a fix here.