### PR TITLE
Update bicepconfig.json on edge to latest

### DIFF
--- a/bicepconfig.json
+++ b/bicepconfig.json
@@ -5,10 +5,7 @@
         "dynamicTypeLoading": true
     },
     "extensions": {
-        "radius": "br:biceptypes.azurecr.io/radius:0.38",
-        "aws": "br:biceptypes.azurecr.io/aws:0.38"
-    },
-    "cloud": {
-        "credentialPrecedence": [ "Environment" ]
+        "radius": "br:biceptypes.azurecr.io/radius:latest",
+        "aws": "br:biceptypes.azurecr.io/aws:latest"
     }
 }


### PR DESCRIPTION
Edge version of bicepconfig.json got updated to 0.38 as a part of upmerge https://github.com/radius-project/samples/pull/1864/files. Edge should always be on the latest version of bicep, so reverting that. Upmerge script/wf will be fixed separately. 