### PR TITLE
Cleanup bicep config

### DIFF
--- a/bicepconfig.json
+++ b/bicepconfig.json
@@ -1,8 +1,6 @@
 {
     "experimentalFeaturesEnabled": {
-        "extensibility": true,
-        "extensionRegistry": true,
-        "dynamicTypeLoading": true
+        "extensibility": true
     },
     "extensions": {
         "radius": "br:biceptypes.azurecr.io/radius:latest",


### PR DESCRIPTION
Some experimental features in the bicepconfig were consolidated in the Bicep repo: https://github.com/Azure/bicep/pull/14944. This PR removes the unnecessary features.