### PR TITLE
Fix upmerge workflow to ignore `bicepconfig`

### DIFF
--- a/.github/workflows/upmerge.yaml
+++ b/.github/workflows/upmerge.yaml
@@ -62,7 +62,9 @@ jobs:
           export SOURCE_BRANCH=$(basename ${{ github.ref }})
           echo "Upmerging samples from $SOURCE_BRANCH to edge"
           git fetch origin $SOURCE_BRANCH
-          git merge -m "Upmerge to edge" origin/$SOURCE_BRANCH
+          git merge --no-commit origin/$SOURCE_BRANCH
+          git checkout edge -- bicepconfig.json
+          git commit -m "Upmerge to edge"
           
           if git diff --quiet edge; then
               echo "No changes to merge from $SOURCE_BRANCH to edge"

--- a/.github/workflows/upmerge.yaml
+++ b/.github/workflows/upmerge.yaml
@@ -57,6 +57,7 @@ jobs:
       # Merge changes from the github.ref branch, i.e., the branch from which the workflow is triggered. That
       # branch is assumed to be the current release branch, but could be any branch.
       # If there are no changes, stop the workflow.
+      # We ignore the bicepconfig.json file because we don't want to overwrite the version in the edge branch.
       - name: Upmerge samples
         run: |
           export SOURCE_BRANCH=$(basename ${{ github.ref }})


### PR DESCRIPTION
Changes were tested in a forked repository 

Test branch used to upmerge to edge with a different bicepconfig and test text: https://github.com/sk593/samples/tree/test-branch
Test upmerge run: https://github.com/sk593/samples/actions/runs/11487885702/job/31973436433
Test PR that was opened with no bicepconfig changes: https://github.com/sk593/samples/pull/3/files


Fixes #1873