### PR TITLE
Add git signoff to the commit in the upmerge workflow

### DIFF
--- a/.github/workflows/upmerge.yaml
+++ b/.github/workflows/upmerge.yaml
@@ -65,7 +65,7 @@ jobs:
           git fetch origin $SOURCE_BRANCH
           git merge --no-commit origin/$SOURCE_BRANCH
           git checkout edge -- bicepconfig.json
-          git commit -m "Upmerge to edge"
+          git commit --signoff --message "Upmerge to edge"
           
           if git diff --quiet edge; then
               echo "No changes to merge from $SOURCE_BRANCH to edge"


### PR DESCRIPTION
## Description

This pull request includes a change to the `.github/workflows/upmerge.yaml` file. The change ensures that commits are signed off when performing an upmerge to the `edge` branch.

* [`.github/workflows/upmerge.yaml`](diffhunk://#diff-ab5db0def1b10f293eba215c2830dd7c303603e87c8e8e7d31e582ad594101b2L71-R71): Modified the `git commit` command to include the [`--signoff` flag](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff), ensuring that commits are [signed off](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository) during the upmerge process.

Git `log` entries for the commit will now look like this, which satisfies the [DCO](https://developercertificate.org/) requirement:

```bash
Author: Radius CI Bot <radiuscoreteam@service.microsoft.com>
Date:   Wed Nov 27 14:52:43 2024 +0000

    Upmerge to edge
    
    Signed-off-by: Radius CI Bot <radiuscoreteam@service.microsoft.com>
```
## Issue reference

Fixes: #1884