### PR TITLE
Remove AWS CLI install from AWS workflows

### DIFF
--- a/.github/workflows/purge-aws-eks-clusters.yaml
+++ b/.github/workflows/purge-aws-eks-clusters.yaml
@@ -1,6 +1,8 @@
 name: Purge AWS EKS Clusters
 
 on:
+  workflow_dispatch:
+    # Allows manual triggering of the workflow
   schedule:
     # Runs every day at 7 AM
     - cron: "0 7 * * *"
@@ -16,11 +18,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Install AWS CLI
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y awscli
 
       - name: Install eksctl
         run: |

--- a/.github/workflows/purge-aws-rds-snapshots.yaml
+++ b/.github/workflows/purge-aws-rds-snapshots.yaml
@@ -1,5 +1,7 @@
 name: Purge AWS RDS DBInstance snapshots
 on:
+  workflow_dispatch:
+    # Allows manual triggering of the workflow
   schedule:
     # Runs at 00:30 and 12:30
     - cron: "30 0,12 * * *"

--- a/.github/workflows/purge-aws-test-resources.yaml
+++ b/.github/workflows/purge-aws-test-resources.yaml
@@ -17,11 +17,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install AWS CLI
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y awscli
-
       - name: Login to AWS
         run: |
           aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -35,6 +30,6 @@ jobs:
       - name: Create GitHub issue on failure
         if: failure() && github.event_name == 'schedule'
         run: |
-          gh issue create --title "Purge Purge AWS Test Resources workflow failed" \
+          gh issue create --title "Purge AWS Test Resources workflow failed" \
             --body "Test failed on ${{ github.repository }}. See [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details." \
             --repo ${{ github.repository }}

--- a/.github/workflows/purge-aws-test-resources.yaml
+++ b/.github/workflows/purge-aws-test-resources.yaml
@@ -1,6 +1,8 @@
 name: Purge AWS Test Resources
 
 on:
+  workflow_dispatch:
+    # Allows manual triggering of the workflow
   schedule:
     # Runs every day at 5 AM
     - cron: "0 5 * * *"


### PR DESCRIPTION
Fixes: https://github.com/radius-project/samples/issues/1966

Not sure why, but `apt-get install awscli` has started failing. The `ubuntu-latest` runner images already have the AWS CLI pre-installed so we should just use that install instead of installing it ourselves. We already do this with the `Purge RDS DBInstances` workflow: https://github.com/radius-project/samples/actions/workflows/purge-aws-rds-snapshots.yaml. I also added `workflow_dispatch` triggers so that we can test this more easily in the future.