### PR TITLE
Add ORAS install to test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,8 @@ on:
     - cron: "0 12 * * *"
 env:
   RUN_IDENTIFIER: samplestest-${{ github.run_id }}-${{ github.run_attempt }}
+  # ORAS (OCI Registry As Storage) CLI version
+  ORAS_VERSION: 1.1.0
 jobs:
   test:
     name: Sample tests
@@ -251,6 +253,10 @@ jobs:
         run: |
           helm repo add dapr https://dapr.github.io/helm-charts/
           helm install dapr dapr/dapr --version=1.6 --namespace dapr-system --create-namespace --wait
+      - uses: oras-project/setup-oras@main
+        if: steps.gen-id.outputs.RUN_TEST == 'true'
+        with:
+          oras-version: ${{ env.ORAS_VERSION }}
       - name: Download rad CLI
         if: steps.gen-id.outputs.RUN_TEST == 'true'
         run: |


### PR DESCRIPTION
Samples test runs are failing because they are trying to pull the rad CLI using oras but it doesn't exist. This PR adds a `setup-oras` step.

Example: https://github.com/radius-project/samples/pull/1967