### PR TITLE
Skip aws-eshop samples test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -105,7 +105,7 @@ jobs:
         run: |
           RUN_IDENTIFIER=${{ env.RUN_IDENTIFIER }}-${{ matrix.name }}
 
-          if [[ "${{ github.event_name }}" == "pull_request" && "${{ matrix.runOnPullRequest }}" == "false" ]]; then
+          if [[ ${{ matrix.credential }}" == "aws" || ( "${{ github.event_name }}" == "pull_request" && "${{ matrix.runOnPullRequest }}" == "false") ]]; then
             RUN_TEST=false
           else
             RUN_TEST=true


### PR DESCRIPTION
Skipping aws-eshop sample tests as dapr helm chart is installed by default since 0.41 release but Dapr has specific instructions for setting up EKS. FYI: https://github.com/radius-project/samples/issues/1901. 
Skipping the test for now until the workflow is fixed to enable dapr pods on EKS.
 