### PR TITLE
Update Test Samples Workflow - Set up Test EKS Cluster for Dapr

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -111,18 +111,11 @@ jobs:
             RUN_TEST=true
           fi
 
-          if [[ "${{ matrix.enableDapr }}" == "true" ]]; then
-            ENABLE_DAPR=true
-          else
-            ENABLE_DAPR=false
-          fi
-
           # Set output variables to be used in the other jobs
           echo "RUN_IDENTIFIER=${RUN_IDENTIFIER}" >> $GITHUB_OUTPUT
           echo "TEST_AZURE_RESOURCE_GROUP=rg-${RUN_IDENTIFIER}" >> $GITHUB_OUTPUT
           echo "TEST_EKS_CLUSTER_NAME=eks-${RUN_IDENTIFIER}" >> $GITHUB_OUTPUT
           echo "RUN_TEST=${RUN_TEST}" >> $GITHUB_OUTPUT
-          echo "ENABLE_DAPR=${ENABLE_DAPR}" >> $GITHUB_OUTPUT
       - name: Generate Radius version variables
         id: gen-radius-version
         if: steps.gen-id.outputs.RUN_TEST == 'true'
@@ -248,11 +241,26 @@ jobs:
           aws eks update-kubeconfig --region ${{ env.AWS_REGION }} --name ${{ steps.gen-id.outputs.TEST_EKS_CLUSTER_NAME }}
         timeout-minutes: 60
         continue-on-error: false
-      - name: Install Dapr
-        if: steps.gen-id.outputs.RUN_TEST == 'true' && steps.gen-id.outputs.ENABLE_DAPR == 'true'
+      - name: Set up EKS for Dapr
+        if: steps.gen-id.outputs.RUN_TEST == 'true' && matrix.credential == 'aws'
         run: |
-          helm repo add dapr https://dapr.github.io/helm-charts/
-          helm install dapr dapr/dapr --version=1.6 --namespace dapr-system --create-namespace --wait
+          # Grab the security group ID for the EKS worker nodes
+          export NODE_SECURITY_GROUP_ID=$(eksctl get nodegroup \
+            --cluster ${{ steps.gen-id.outputs.TEST_EKS_CLUSTER_NAME }} \
+            --name <your-nodegroup-name> \
+            --region ${{ env.AWS_REGION }} \
+            -o json | jq -r '.[0].Resources.SecurityGroup.ID')
+
+          # Authorize port 4000 for Dapr sidecar communication
+          # https://docs.dapr.io/operations/hosting/kubernetes/cluster/setup-eks/#add-dapr-requirements-for-sidecar-access-and-default-storage-class
+          aws ec2 authorize-security-group-ingress \
+            --group-id $NODE_SECURITY_GROUP_ID \
+            --protocol tcp \
+            --port 4000 \
+            --cidr 0.0.0.0/0
+
+          # Add a default storage class
+          kubectl patch storageclass gp2 -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
       - uses: oras-project/setup-oras@main
         if: steps.gen-id.outputs.RUN_TEST == 'true'
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -226,41 +226,56 @@ jobs:
         if: steps.gen-id.outputs.RUN_TEST == 'true' && matrix.credential == 'aws'
         id: create-eks
         run: |
+          # Install eksctl
           curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
           sudo mv /tmp/eksctl /usr/local/bin
+
+          # Create EKS cluster
           eksctl create cluster \
             --name ${{ steps.gen-id.outputs.TEST_EKS_CLUSTER_NAME }} \
             --nodes-min 1 --nodes-max 2 --node-type t3.large \
             --zones ${{ env.AWS_ZONES }} \
             --managed \
             --region ${{ env.AWS_REGION }}
+
+          # Wait for the EKS cluster to be active
           while [[ "$(eksctl get cluster ${{ steps.gen-id.outputs.TEST_EKS_CLUSTER_NAME }} --region ${{ env.AWS_REGION }} -o json | jq -r .[0].Status)" != "ACTIVE" ]]; do
             echo "Waiting for EKS cluster to be created..."
             sleep 60
           done
+
+          # Update kubeconfig
           aws eks update-kubeconfig --region ${{ env.AWS_REGION }} --name ${{ steps.gen-id.outputs.TEST_EKS_CLUSTER_NAME }}
         timeout-minutes: 60
         continue-on-error: false
-      - name: Set up EKS for Dapr
+      - name: Configure EKS for Dapr
         if: steps.gen-id.outputs.RUN_TEST == 'true' && matrix.credential == 'aws'
         run: |
-          # Grab the security group ID for the EKS worker nodes
-          export NODE_SECURITY_GROUP_ID=$(eksctl get nodegroup \
+          # Fetch the node group name dynamically
+          NODEGROUP_NAME=$(eksctl get nodegroup \
             --cluster ${{ steps.gen-id.outputs.TEST_EKS_CLUSTER_NAME }} \
-            --name <your-nodegroup-name> \
+            --region ${{ env.AWS_REGION }} \
+            -o json | jq -r '.[0].Name')
+
+          # Fetch the security group ID for the EKS worker nodes
+          NODE_SECURITY_GROUP_ID=$(eksctl get nodegroup \
+            --cluster ${{ steps.gen-id.outputs.TEST_EKS_CLUSTER_NAME }} \
+            --name $NODEGROUP_NAME \
             --region ${{ env.AWS_REGION }} \
             -o json | jq -r '.[0].Resources.SecurityGroup.ID')
 
-          # Authorize port 4000 for Dapr sidecar communication
+          # Authorize port 4000 for Dapr sidecar communication within the same security group
           # https://docs.dapr.io/operations/hosting/kubernetes/cluster/setup-eks/#add-dapr-requirements-for-sidecar-access-and-default-storage-class
           aws ec2 authorize-security-group-ingress \
             --group-id $NODE_SECURITY_GROUP_ID \
             --protocol tcp \
             --port 4000 \
-            --cidr 0.0.0.0/0
+            --source-group $NODE_SECURITY_GROUP_ID
 
           # Add a default storage class
           kubectl patch storageclass gp2 -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+        timeout-minutes: 30
+        continue-on-error: false
       - uses: oras-project/setup-oras@main
         if: steps.gen-id.outputs.RUN_TEST == 'true'
         with:


### PR DESCRIPTION
[This](https://github.com/radius-project/radius/issues/8032) change updated Radius installation to always install Dapr, which is causing failures in eshop-aws workflow which runs on EKS cluster, as the cluster is lacking the required prerequisites for Dapr through the approach taken in the Radius CLI.

This is causing consistent sample failures and operational pain during every release.

Fixes: https://github.com/radius-project/samples/issues/1901 and https://github.com/radius-project/radius/issues/8141