### PR TITLE
Increase timeout from 3 mins to 5 mins for registering manifests.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -304,8 +304,8 @@ jobs:
             exit 1
           fi
 
-          # Poll logs for up to  iterations, 30 seconds each (upto 3 minutes total)
-          for i in {1..6}; do
+          # Poll logs for up to  iterations, 30 seconds each (upto 5 minutes total)
+          for i in {1..10}; do
             kubectl logs "$POD_NAME" -n radius-system | tee registermanifest_logs.txt > /dev/null
 
             # Exit on error


### PR DESCRIPTION
Increase timeout from 3 mins to 5 mins for registering manifests.