### PR TITLE
increase cpu

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -233,7 +233,7 @@ jobs:
           # Create EKS cluster
           eksctl create cluster \
             --name ${{ steps.gen-id.outputs.TEST_EKS_CLUSTER_NAME }} \
-            --nodes-min 1 --nodes-max 2 --node-type t3.large \
+            --nodes-min 1 --nodes-max 2 --node-type t3.xlarge \
             --zones ${{ env.AWS_ZONES }} \
             --managed \
             --region ${{ env.AWS_REGION }}


### PR DESCRIPTION
Increasing cpu of eks to address database pod issues:
```
nithya@MacBook-Pro ~ % k describe -n radius-system pod database-0 
Name:             database-0
Namespace:        radius-system
Priority:         0
Service Account:  database
Node:             <none>
Labels:           app.kubernetes.io/name=database
                  app.kubernetes.io/part-of=radius
                  apps.kubernetes.io/pod-index=0
                  control-plane=database
                  controller-revision-hash=database-f9df69f78
                  statefulset.kubernetes.io/pod-name=database-0
Annotations:      <none>
Status:           Pending
IP:               
IPs:              <none>
Controlled By:    StatefulSet/database
Containers:
  database:
    Image:      ghcr.io/radius-project/mirror/postgres:latest
    Port:       5432/TCP
    Host Port:  0/TCP
    Limits:
      cpu:     2
      memory:  1Gi
    Requests:
      cpu:     2
      memory:  512Mi
    Environment:
      POSTGRES_DB:        <set to the key 'POSTGRES_DB' in secret 'database-secret'>        Optional: false
      POSTGRES_USER:      <set to the key 'POSTGRES_USER' in secret 'database-secret'>      Optional: false
      POSTGRES_PASSWORD:  <set to the key 'POSTGRES_PASSWORD' in secret 'database-secret'>  Optional: false
    Mounts:
      /var/lib/postgresql/data from database (rw,path="postgres")
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-bgpl6 (ro)
Conditions:
  Type           Status
  PodScheduled   False 
Volumes:
  database:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  database-database-0
    ReadOnly:   false
  kube-api-access-bgpl6:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   Burstable
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type     Reason            Age                From               Message
  ----     ------            ----               ----               -------
  Warning  FailedScheduling  89s (x5 over 21m)  default-scheduler  0/1 nodes are available: 1 Insufficient cpu. preemption: 0/1 nodes are available: 1 No preemption victims found for incoming pod.
nithya@MacBook-Pro ~ % 

```