### PR TITLE
Adding target-branch property to the dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    target-branch: "edge"
     groups:
       all:
         patterns:
@@ -12,6 +13,7 @@ updates:
     directory: "/samples/aws-sqs"
     schedule:
       interval: "weekly"
+    target-branch: "edge"
     groups:
       all:
         patterns:
@@ -19,29 +21,32 @@ updates:
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: "weekly"
+    target-branch: "edge"
     groups:
       all:
         patterns:
           - "*"
   - package-ecosystem: "npm"
-    directories: 
+    directories:
       - "/playwright"
       - "/samples/dapr/nodeapp"
       - "/samples/demo"
       - "/samples/demo/client"
     schedule:
       interval: "weekly"
+    target-branch: "edge"
     groups:
       all:
         patterns:
           - "*"
   - package-ecosystem: "nuget"
-    directories: 
+    directories:
       - "/samples/aws"
       - "/samples/dapr/ui"
     schedule:
       interval: "weekly"
+    target-branch: "edge"
     groups:
       all:
         patterns:
@@ -50,6 +55,7 @@ updates:
     directory: "/samples/volumes/src"
     schedule:
       interval: "weekly"
+    target-branch: "edge"
     groups:
       all:
         patterns:


### PR DESCRIPTION
Adding target-branch property to the dependabot.yml so that it can check and create PRs against edge (#2210)

Signed-off-by: ytimocin <ytimocin@microsoft.com>
(cherry picked from commit 9e0a5b564703253706ebfa7f78c6fe38aab9e57c)