### PR TITLE
Sign release commit with the release workflow

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,6 +26,7 @@
 			"ms-python.python",
 			"dunn.redis",
 			"GitHub.copilot",
+			"github.vscode-github-actions",
 			"ms-azuretools.vscode-bicep"
 		]
 	  }

--- a/.github/scripts/release-samples.sh
+++ b/.github/scripts/release-samples.sh
@@ -56,7 +56,7 @@ cat bicepconfig.json
 echo "Running git diff..."
 git diff
 git add --all
-git commit -m "Update samples for ${CHANNEL_VERSION}"
+git commit --signoff -message "Update samples for ${CHANNEL_VERSION}"
 git push origin "${CHANNEL_VERSION}"
 
 popd

--- a/.github/scripts/release-samples.sh
+++ b/.github/scripts/release-samples.sh
@@ -56,7 +56,7 @@ cat bicepconfig.json
 echo "Running git diff..."
 git diff
 git add --all
-git commit --signoff -message "Update samples for ${CHANNEL_VERSION}"
+git commit --signoff --message "Update samples for ${CHANNEL_VERSION}"
 git push origin "${CHANNEL_VERSION}"
 
 popd


### PR DESCRIPTION
This pull request includes updates to sign the release commit during the `release.yaml` workflow. There is also a minor update to the dev container. 

This PR fixes #2201 

Release script improvements:

* [`.github/scripts/release-samples.sh`](diffhunk://#diff-082a60d2b3dc81ac31f0d4db5219e595a99cd2cc7fac546a42cf3aeb99fa8949L59-R59): Modified the `git commit` command to include the `--signoff` flag for better commit message practices.

Development container configuration:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R29): Added the `github.vscode-github-actions` extension to the list of recommended extensions.