### PR TITLE
Fix dependabot for dev containers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,10 +23,6 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "edge"
-    groups:
-      all:
-        patterns:
-          - "*"
   - package-ecosystem: "npm"
     directories:
       - "/playwright"


### PR DESCRIPTION
This pull request includes a change to the `.github/dependabot.yml` file. The change removes the `groups` section on the `devcontainers` package ecosystem, which resolves an error when running the dev container dependabot update.

I tested this change on a fork and was able to reproduce the issue and verify the fix.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L26-L29): Removed the `groups` section and its patterns.