### PR TITLE
Fix samples build failures on push to edge

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,13 @@ on:
     branches:
       - edge
       - v*.*
+  pull_request:
+    branches:
+      - edge
+      - v*.*
+    paths:
+      - 'samples/**'
+      - '.github/workflows/build.yaml'
 
 env:
   VERSION: 'latest'

--- a/samples/aws/Dockerfile
+++ b/samples/aws/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 5234
 
@@ -9,7 +9,7 @@ ENV ASPNETCORE_URLS=http://+:5234
 RUN adduser -u 5678 --disabled-password --gecos "" appuser && chown -R appuser /app
 USER appuser
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["aws.csproj", "./"]
 RUN dotnet restore "aws.csproj"

--- a/samples/aws/aws.csproj
+++ b/samples/aws/aws.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
@@ -9,6 +9,9 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="4.0.7.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="9.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/volumes/Dockerfile
+++ b/samples/volumes/Dockerfile
@@ -2,7 +2,8 @@ FROM alpine:3.14
 RUN apk add --no-cache python3 py3-pip
 COPY ./src/requirements.txt /app/requirements.txt
 WORKDIR /app
-RUN pip install -r requirements.txt
+RUN python3 -m pip install --upgrade pip setuptools wheel \
+    && python3 -m pip install --no-cache-dir -r requirements.txt
 COPY ./src /app
 ENTRYPOINT [ "python3" ]
 CMD [ "app.py" ]


### PR DESCRIPTION
I'm seeing failures when we push to edge: https://github.com/radius-project/samples/actions/runs/18021446141/job/51279482210

It looks like today, we run the `build.yaml` workflow only on push. This means we could see regressions that are only spotted on push.

This PR adds the PR trigger to this workflow (to verify that it works in PR) and fixes an underlying issue with the samples/aws build.

Also fixes the samples/volumes: https://github.com/radius-project/samples/actions/runs/18106274362/job/51521538161?pr=2373