### PR TITLE
Dev container lock file

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,24 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/azure-cli:1": {
+      "version": "1.2.9",
+      "resolved": "ghcr.io/devcontainers/features/azure-cli@sha256:4549175fbfd3475d1d62e82f6e5425d03954a6ae06027b2515b0ba41a8206417",
+      "integrity": "sha256:4549175fbfd3475d1d62e82f6e5425d03954a6ae06027b2515b0ba41a8206417"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "2.16.1",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:ce078b7bf7d9ef3bcb9813b32103795d8d72172446890b64772cbe1dec6baafd",
+      "integrity": "sha256:ce078b7bf7d9ef3bcb9813b32103795d8d72172446890b64772cbe1dec6baafd"
+    },
+    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+      "version": "1.3.1",
+      "resolved": "ghcr.io/devcontainers/features/kubectl-helm-minikube@sha256:bbe8adf6b37fff8c67412ab0a4579f4c2f30bbaba1d9a5cebd9e38bade54025b",
+      "integrity": "sha256:bbe8adf6b37fff8c67412ab0a4579f4c2f30bbaba1d9a5cebd9e38bade54025b"
+    },
+    "ghcr.io/rio/features/k3d:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/rio/features/k3d@sha256:0ada2620215533142ee90ac19e5903c345418a51d23457cd0b3da142013a8464",
+      "integrity": "sha256:0ada2620215533142ee90ac19e5903c345418a51d23457cd0b3da142013a8464"
+    }
+  }
+}

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,21 +1,21 @@
 {
   "features": {
-    "ghcr.io/devcontainers/features/azure-cli:1": {
+    "ghcr.io/devcontainers/features/azure-cli:1.2.9": {
       "version": "1.2.9",
       "resolved": "ghcr.io/devcontainers/features/azure-cli@sha256:4549175fbfd3475d1d62e82f6e5425d03954a6ae06027b2515b0ba41a8206417",
       "integrity": "sha256:4549175fbfd3475d1d62e82f6e5425d03954a6ae06027b2515b0ba41a8206417"
     },
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2.16.1": {
       "version": "2.16.1",
       "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:ce078b7bf7d9ef3bcb9813b32103795d8d72172446890b64772cbe1dec6baafd",
       "integrity": "sha256:ce078b7bf7d9ef3bcb9813b32103795d8d72172446890b64772cbe1dec6baafd"
     },
-    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1.3.1": {
       "version": "1.3.1",
       "resolved": "ghcr.io/devcontainers/features/kubectl-helm-minikube@sha256:bbe8adf6b37fff8c67412ab0a4579f4c2f30bbaba1d9a5cebd9e38bade54025b",
       "integrity": "sha256:bbe8adf6b37fff8c67412ab0a4579f4c2f30bbaba1d9a5cebd9e38bade54025b"
     },
-    "ghcr.io/rio/features/k3d:1": {
+    "ghcr.io/rio/features/k3d:1.1.0": {
       "version": "1.1.0",
       "resolved": "ghcr.io/rio/features/k3d@sha256:0ada2620215533142ee90ac19e5903c345418a51d23457cd0b3da142013a8464",
       "integrity": "sha256:0ada2620215533142ee90ac19e5903c345418a51d23457cd0b3da142013a8464"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,10 +9,10 @@
 	],
 	// Features to add to the dev container. More info: https://containers.dev/features
 	"features": {
-	  "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-	  "ghcr.io/devcontainers/features/azure-cli:1": {},
-	  "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
-	  "ghcr.io/rio/features/k3d:1": {}
+	  "ghcr.io/devcontainers/features/docker-in-docker:2.16.1": {},
+	  "ghcr.io/devcontainers/features/azure-cli:1.2.9": {},
+	  "ghcr.io/devcontainers/features/kubectl-helm-minikube:1.3.1": {},
+	  "ghcr.io/rio/features/k3d:1.1.0": {}
 	},
 	// Configure tool-specific properties.
 	"customizations": {


### PR DESCRIPTION
This pull request adds a new `.devcontainer/devcontainer-lock.json` file that specifies the versions and integrity hashes for several development container features. This helps ensure consistent tooling and environment setup for anyone using the dev container.

Development environment setup:

* Added `azure-cli` feature version `1.2.9` with integrity hash to lock Azure CLI in the dev container.
* Added `docker-in-docker` feature version `2.16.1` to enable Docker usage inside the dev container.
* Added `kubectl-helm-minikube` feature version `1.3.1` to provide Kubernetes, Helm, and Minikube tools in the dev container.
* Added `k3d` feature version `1.1.0` to support running lightweight Kubernetes clusters inside Docker.