### PR TITLE
Remove multi-ecosystem-group from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,10 @@ updates:
       day: monday
       time: "07:00"
       timezone: America/Los_Angeles
-    patterns:
-      - "*"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: gomod
     directory: /samples/aws-sqs
@@ -24,8 +26,10 @@ updates:
       day: monday
       time: "07:00"
       timezone: America/Los_Angeles
-    patterns:
-      - "*"
+    groups:
+      gomod:
+        patterns:
+          - "*"
 
   - package-ecosystem: devcontainers
     directory: /
@@ -35,8 +39,10 @@ updates:
       day: monday
       time: "07:00"
       timezone: America/Los_Angeles
-    patterns:
-      - "*"
+    groups:
+      devcontainers:
+        patterns:
+          - "*"
 
   - package-ecosystem: npm
     directories:
@@ -50,8 +56,10 @@ updates:
       day: monday
       time: "07:00"
       timezone: America/Los_Angeles
-    patterns:
-      - "*"
+    groups:
+      npm:
+        patterns:
+          - "*"
     ignore:
       - dependency-name: "*"
         update-types:
@@ -68,8 +76,10 @@ updates:
       day: monday
       time: "07:00"
       timezone: America/Los_Angeles
-    patterns:
-      - "*"
+    groups:
+      nuget:
+        patterns:
+          - "*"
 
   - package-ecosystem: pip
     directory: /samples/volumes/src
@@ -79,8 +89,10 @@ updates:
       day: monday
       time: "07:00"
       timezone: America/Los_Angeles
-    patterns:
-      - "*"
+    groups:
+      pip:
+        patterns:
+          - "*"
 
   - package-ecosystem: gitsubmodule
     directory: /
@@ -90,5 +102,7 @@ updates:
       day: monday
       time: "07:00"
       timezone: America/Los_Angeles
-    patterns:
-      - "*"
+    groups:
+      gitsubmodule:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,31 +4,37 @@
 ---
 version: 2
 
-multi-ecosystem-groups:
-  edge-weekly:
+updates:
+  - package-ecosystem: github-actions
+    directory: /
     target-branch: edge
     schedule:
       interval: weekly
       day: monday
-      time: 07:00
+      time: "07:00"
       timezone: America/Los_Angeles
-
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    multi-ecosystem-group: edge-weekly
     patterns:
       - "*"
 
   - package-ecosystem: gomod
     directory: /samples/aws-sqs
-    multi-ecosystem-group: edge-weekly
+    target-branch: edge
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: America/Los_Angeles
     patterns:
       - "*"
 
   - package-ecosystem: devcontainers
     directory: /
-    multi-ecosystem-group: edge-weekly
+    target-branch: edge
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: America/Los_Angeles
     patterns:
       - "*"
 
@@ -38,7 +44,12 @@ updates:
       - /samples/dapr/nodeapp
       - /samples/demo
       - /samples/demo/client
-    multi-ecosystem-group: edge-weekly
+    target-branch: edge
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: America/Los_Angeles
     patterns:
       - "*"
     ignore:
@@ -51,18 +62,33 @@ updates:
     directories:
       - /samples/aws
       - /samples/dapr/ui
-    multi-ecosystem-group: edge-weekly
+    target-branch: edge
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: America/Los_Angeles
     patterns:
       - "*"
 
   - package-ecosystem: pip
     directory: /samples/volumes/src
-    multi-ecosystem-group: edge-weekly
+    target-branch: edge
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: America/Los_Angeles
     patterns:
       - "*"
 
   - package-ecosystem: gitsubmodule
     directory: /
-    multi-ecosystem-group: edge-weekly
+    target-branch: edge
+    schedule:
+      interval: weekly
+      day: monday
+      time: "07:00"
+      timezone: America/Los_Angeles
     patterns:
       - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,10 +39,6 @@ updates:
       day: monday
       time: "07:00"
       timezone: America/Los_Angeles
-    groups:
-      devcontainers:
-        patterns:
-          - "*"
 
   - package-ecosystem: npm
     directories:


### PR DESCRIPTION
This pull request updates the Dependabot configuration to remove the use of malfunctioning `multi-ecosystem-groups` in favor of `groups` properties for grouping updates. It also standardizes the update schedule and target branch settings across all package ecosystems.

Configuration improvements:

* Replaces the `multi-ecosystem-groups` with the `groups` property for each package ecosystem, ensuring future compatibility and proper grouping of update PRs. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L7-R56) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L54-R102)
* Adds explicit `target-branch: edge`, weekly schedules, and timezone settings to each ecosystem's update configuration, ensuring consistency and clarity. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L7-R56) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L54-R102)
* Moves the update scheduling and grouping settings directly under each package ecosystem, removing the shared group mechanism. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L7-R56) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L54-R102)