### PR TITLE
Add Dependabot cooldown to all updates entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
       day: monday
       time: "07:00"
       timezone: America/Los_Angeles
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:
@@ -26,6 +28,8 @@ updates:
       day: monday
       time: "07:00"
       timezone: America/Los_Angeles
+    cooldown:
+      default-days: 7
     groups:
       gomod:
         patterns:
@@ -39,6 +43,8 @@ updates:
       day: monday
       time: "07:00"
       timezone: America/Los_Angeles
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: npm
     directories:
@@ -52,6 +58,8 @@ updates:
       day: monday
       time: "07:00"
       timezone: America/Los_Angeles
+    cooldown:
+      default-days: 7
     groups:
       npm:
         patterns:
@@ -72,6 +80,8 @@ updates:
       day: monday
       time: "07:00"
       timezone: America/Los_Angeles
+    cooldown:
+      default-days: 7
     groups:
       nuget:
         patterns:
@@ -85,6 +95,8 @@ updates:
       day: monday
       time: "07:00"
       timezone: America/Los_Angeles
+    cooldown:
+      default-days: 7
     groups:
       pip:
         patterns:
@@ -98,6 +110,8 @@ updates:
       day: monday
       time: "07:00"
       timezone: America/Los_Angeles
+    cooldown:
+      default-days: 7
     groups:
       gitsubmodule:
         patterns:


### PR DESCRIPTION
## Description

Adds a `cooldown` block to every active `updates:` entry in `.github/dependabot.yml`:

```yaml
cooldown:
  default-days: 7
```

The cooldown block delays Dependabot update PRs until 7 days after a dependency release, reducing PR churn from brand-new releases (which are more likely to be quickly superseded or yanked). It is applied uniformly across all 7 active ecosystems: github-actions, gomod, devcontainers, npm, nuget, pip, and gitsubmodule.

This change is scoped to this repository and is part of an org-wide rollout following [radius-project/radius #12141](https://github.com/radius-project/radius/pull/12141) ("Add Dependabot cooldown to all updates entries").

## Type of change

- This is a maintenance / no-functional-change task (CI / tooling configuration only).

## Notes

- Base branch is `edge` (not the release/default branch), per the org rollout process.
- The file remains valid YAML and schema-valid against the Dependabot v2 / schemastore 2.0 schema.
- Commented-out entries and entries already having a `cooldown:` block were not modified (none were present).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>