### PR TITLE
Add Azure resource type samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,20 @@ The current repository offers a codespace setup with Radius and its dependencies
 | **eshop** | A Rad-ified version of eShop on Containers, the .NET reference app
 | **eshop-dapr** | A Rad-ified version of eShop on Dapr
 | **volumes** | An app to interact with mounted volumes
+
+### Resource type samples
+
+Each of these samples connects a real third-party application to a cloud resource provisioned through a Radius resource type wired directly to a standard Azure Verified Module (AVM). Every directory is self-contained (`app.bicep`, `env-azure.bicep`, `bicepconfig.json`, and any application source) with its own README.
+
+| Sample | Resource type | Application |
+|--------|---------------|-------------|
+| **kafka-ui** | `Radius.Messaging/kafka` (Azure Event Hubs) | Kafbat Kafka UI |
+| **berriai-litellm** | `Radius.AI/models` (Azure OpenAI) | LiteLLM proxy |
+| **mongo-express-mongo-express** | `Radius.Data/mongoDatabases` (Azure Cosmos DB for MongoDB) | mongo-express |
+| **dockersamples-todo-list-app** | `Radius.Data/mySqlDatabases` (Azure MySQL) | Docker todo-list-app |
+| **sosedoff-pgweb** | `Radius.Data/postgreSqlDatabases` (Azure PostgreSQL) | pgweb, built from source and run |
+| **warpstreamlabs-bento** | `Radius.Messaging/rabbitMQ` (Azure Service Bus) | Bento streaming pipeline, built from source |
+| **radius-project-samples-demo** | `Radius.Data/redisCaches` (Azure Managed Redis) | Radius samples demo app |
+| **sqlpad-sqlpad** | `Radius.Data/sqlServerDatabases` (Azure SQL) | SQLPad SQL client UI, built from source |
+| **azure-search-api** | `Radius.AI/search` (Azure AI Search) | Go search API service, built from source |
+| **drakkan-sftpgo** | `Radius.Storage/objectStorage` (Azure Blob Storage) | SFTPGo |

--- a/samples/azure-search-api/README.md
+++ b/samples/azure-search-api/README.md
@@ -1,0 +1,35 @@
+# Go search API service + Radius.AI/search (Azure AI Search)
+
+This sample provisions an Azure AI Search service through `Radius.AI/search` using an Azure Verified Module (AVM) recipe. It builds and runs a small Go HTTP API that stores documents in the search index and queries them through the Azure AI Search REST API.
+
+## What this sample shows
+- **Resource type:** `Radius.AI/search`
+- **Cloud backing (Azure):** Azure AI Search via the AVM `mcr.microsoft.com/bicep/avm/res/search/search-service:0.12.2` module (`env-azure.bicep`).
+- **Application:** Go search API service `v1`, built from source via `Radius.Compute/containerImages` and run via `imageReference`.
+- **Credential model:** The recipe exposes the admin key under nested `outputs.secrets.apiKey`. The app declares `connections.search` (Radius auto-injects the non-secret `CONNECTION_SEARCH_ENDPOINT`) and consumes the key explicitly as `CONNECTION_SEARCH_APIKEY` via a `secretKeyRef` backed by `searchService.properties.secrets`, which the Go service reads.
+
+## Files
+| File | Role |
+| --- | --- |
+| `app.bicep` | Developer view: the Radius application, search resource, search API image build, and search API container. |
+| `env-azure.bicep` | Platform-engineer view: the `recipePacks` binding the type to the AVM module plus supporting recipes, and the `environment`. |
+| `bicepconfig.json` | Radius Bicep extension configuration. |
+| `src/` | Go source for the search API service (stdlib only), its tests, and Dockerfile. |
+
+## Deploying
+Deploy `env-azure.bicep` (the environment) first, then `app.bicep`.
+
+This sample builds its container image from source with a `Radius.Compute/containerImages` recipe and pushes it to a registry you supply. When deploying `env-azure.bicep`, provide:
+- `containerImagesRegistry` — an OCI registry you can push to (e.g. `ghcr.io/your-org`).
+- `containerImagesRegistrySecretName` — the name of a Kubernetes Secret (`username`/`password`) in the environment namespace, used to authenticate the BuildKit **push** of the built image. Create it before deploying.
+
+Image **pull** auth is separate: the `containerImages` recipe does not configure kubelet pull credentials, so the built image repository must be publicly readable by the cluster, or you must configure a Kubernetes image-pull secret (e.g. a `kubernetes.io/dockerconfigjson` `imagePullSecret` on the namespace's `default` ServiceAccount) before deploying `app.bicep` — otherwise the app pods fail with `ImagePullBackOff`.
+
+## Notes
+The containerImages recipe builds from `git::https://github.com/radius-project/samples.git//samples/azure-search-api/src?ref=edge`; this source lands in this repo on merge. The service uses only the Go standard library, calls Azure AI Search REST API version `2024-07-01`, ensures an index on startup, and exposes `GET /healthz`, `POST /documents`, and `GET /search?q=...` on port 8080.
+
+The default index name is `radius-sample`, overridable with `SEARCH_INDEX_NAME`. `POST /documents` accepts JSON documents with `id` and `content`, and `/search` returns the upstream Azure AI Search JSON response.
+
+Additional deployment details:
+- The Azure AI Search service uses the Basic SKU with one replica and one partition.
+- The container image builds with the Dockerfile under `src/`.

--- a/samples/azure-search-api/app.bicep
+++ b/samples/azure-search-api/app.bicep
@@ -1,0 +1,64 @@
+extension radius
+
+@description('The ID of your Radius Environment. Set automatically by the rad CLI.')
+param environment string
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'search-azure-app-test'
+  properties: {
+    environment: environment
+  }
+}
+
+resource searchService 'Radius.AI/search@2025-08-01-preview' = {
+  name: 'search'
+  properties: {
+    environment: environment
+    application: app.id
+  }
+}
+
+resource searchApiImage 'Radius.Compute/containerImages@2025-08-01-preview' = {
+  name: 'search-api-image'
+  properties: {
+    environment: environment
+    application: app.id
+    tag: 'v1'
+    build: {
+      source: 'git::https://github.com/radius-project/samples.git//samples/azure-search-api/src?ref=edge'
+    }
+  }
+}
+
+resource searchapictr 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'searchapictr'
+  properties: {
+    environment: environment
+    application: app.id
+    containers: {
+      searchapi: {
+        image: searchApiImage.properties.imageReference
+        ports: {
+          web: {
+            containerPort: 8080
+          }
+        }
+        env: {
+          CONNECTION_SEARCH_APIKEY: {
+            valueFrom: {
+              secretKeyRef: {
+                secretName: searchService.properties.secrets.name
+                key: 'apiKey'
+              }
+            }
+          }
+        }
+      }
+    }
+    connections: {
+      search: {
+        source: searchService.id
+      }
+    }
+  }
+}

--- a/samples/azure-search-api/bicepconfig.json
+++ b/samples/azure-search-api/bicepconfig.json
@@ -1,0 +1,8 @@
+{
+  "experimentalFeaturesEnabled": {
+    "extensibility": true
+  },
+  "extensions": {
+    "radius": "br:biceptypes.azurecr.io/radius:latest"
+  }
+}

--- a/samples/azure-search-api/env-azure.bicep
+++ b/samples/azure-search-api/env-azure.bicep
@@ -1,0 +1,86 @@
+extension radius
+
+@description('Azure subscription ID the environment provisions resources into.')
+param azureSubscriptionId string
+
+@description('Azure resource group the environment provisions resources into. Must already exist.')
+param azureResourceGroup string
+
+@description('Globally-unique Azure AI Search service name (2-60 lowercase letters, digits, or hyphens; cannot start or end with a hyphen). The workflow generates a unique value per run.')
+param searchServiceName string
+
+@description('OCI ref for the Radius.Compute/containers recipe. Override to a custom build if needed; defaults to the released public recipe.')
+param containersRecipe string = 'ghcr.io/radius-project/kube-recipes/containers:latest'
+
+@description('OCI registry the containerImages recipe builds and pushes the search-api image to (e.g. `ghcr.io/myorg`).')
+param containerImagesRegistry string
+
+@description('Kubernetes Secret (in the environment namespace) holding the push registry `username`/`password`.')
+param containerImagesRegistrySecretName string
+
+resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
+  name: 'search-azure-avm'
+  properties: {
+    recipes: {
+      'Radius.AI/search': {
+        kind: 'bicep'
+
+        source: 'mcr.microsoft.com/bicep/avm/res/search/search-service:0.12.2'
+        parameters: {
+          name: searchServiceName
+          sku: 'basic'
+          disableLocalAuth: false
+          replicaCount: 1
+          partitionCount: 1
+
+          enableTelemetry: false
+        }
+
+        outputs: {
+          endpoint: 'endpoint'
+          secrets: {
+            apiKey: 'primaryKey'
+          }
+        }
+      }
+
+      'Radius.Compute/containers': {
+        kind: 'bicep'
+        source: containersRecipe
+      }
+
+      'Radius.Security/secrets': {
+        kind: 'bicep'
+        source: 'ghcr.io/radius-project/kube-recipes/secrets:latest'
+      }
+
+      'Radius.Compute/containerImages': {
+        kind: 'terraform'
+        source: 'git::https://github.com/radius-project/resource-types-contrib.git//Compute/containerImages/recipes/kubernetes/terraform?ref=b9e0fad536a53349b98f94c5be961db84845e1b7'
+        parameters: {
+          registry: containerImagesRegistry
+          registrySecretName: containerImagesRegistrySecretName
+        }
+      }
+    }
+  }
+}
+
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
+  name: 'azure'
+  properties: {
+    providers: {
+      azure: {
+        subscriptionId: azureSubscriptionId
+        resourceGroupName: azureResourceGroup
+      }
+
+      kubernetes: {
+        namespace: 'default'
+      }
+    }
+    recipePacks: [
+      recipes.id
+    ]
+  }
+}

--- a/samples/azure-search-api/src/Dockerfile
+++ b/samples/azure-search-api/src/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.23-alpine AS build
+WORKDIR /src
+COPY go.mod ./
+COPY *.go ./
+RUN CGO_ENABLED=0 GOOS=linux go build -o /out/azure-search-api .
+
+FROM gcr.io/distroless/static-debian12
+COPY --from=build /out/azure-search-api /azure-search-api
+EXPOSE 8080
+USER nonroot:nonroot
+ENTRYPOINT ["/azure-search-api"]

--- a/samples/azure-search-api/src/go.mod
+++ b/samples/azure-search-api/src/go.mod
@@ -1,0 +1,3 @@
+module github.com/radius-project/samples/azure-search-api
+
+go 1.23

--- a/samples/azure-search-api/src/handlers.go
+++ b/samples/azure-search-api/src/handlers.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+type Server struct {
+	client *SearchClient
+	logger *log.Logger
+}
+
+func NewServer(client *SearchClient, logger *log.Logger) http.Handler {
+	if logger == nil {
+		logger = log.Default()
+	}
+	server := &Server{client: client, logger: logger}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", server.healthz)
+	mux.HandleFunc("/documents", server.documents)
+	mux.HandleFunc("/search", server.search)
+	return mux
+}
+
+func (s *Server) healthz(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	w.Header().Set("content-type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"status":"ok"}`))
+}
+
+func (s *Server) documents(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	defer r.Body.Close()
+
+	var doc Document
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&doc); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON document")
+		return
+	}
+	if doc.ID == "" || doc.Content == "" {
+		writeError(w, http.StatusBadRequest, "id and content are required")
+		return
+	}
+
+	if err := s.client.UploadDocument(r.Context(), doc); err != nil {
+		s.logger.Printf("document upload failed: %v", err)
+		writeError(w, http.StatusBadGateway, "search service request failed")
+		return
+	}
+
+	w.Header().Set("content-type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"status":"ok"}`))
+}
+
+func (s *Server) search(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	query := r.URL.Query().Get("q")
+	if query == "" {
+		writeError(w, http.StatusBadRequest, "q query parameter is required")
+		return
+	}
+
+	body, err := s.client.Search(r.Context(), query)
+	if err != nil {
+		s.logger.Printf("search failed: %v", err)
+		writeError(w, http.StatusBadGateway, "search service request failed")
+		return
+	}
+
+	w.Header().Set("content-type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("content-type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+}

--- a/samples/azure-search-api/src/main.go
+++ b/samples/azure-search-api/src/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+const (
+	defaultPort      = "8080"
+	defaultIndexName = "radius-sample"
+)
+
+func main() {
+	logger := log.New(os.Stdout, "azure-search-api: ", log.LstdFlags)
+
+	port := getenvDefault("PORT", defaultPort)
+	indexName := getenvDefault("SEARCH_INDEX_NAME", defaultIndexName)
+	client := NewSearchClient(
+		os.Getenv("CONNECTION_SEARCH_ENDPOINT"),
+		os.Getenv("CONNECTION_SEARCH_APIKEY"),
+		indexName,
+		&http.Client{Timeout: 30 * time.Second},
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	if err := client.EnsureIndex(ctx); err != nil {
+		logger.Printf("warning: unable to ensure search index %q at startup: %v", indexName, err)
+	} else {
+		logger.Printf("search index %q is ready", indexName)
+	}
+	cancel()
+
+	addr := ":" + port
+	logger.Printf("listening on %s", addr)
+	if err := http.ListenAndServe(addr, NewServer(client, logger)); err != nil {
+		logger.Fatalf("server stopped: %v", err)
+	}
+}
+
+func getenvDefault(name, fallback string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+	return fallback
+}

--- a/samples/azure-search-api/src/main_test.go
+++ b/samples/azure-search-api/src/main_test.go
@@ -1,0 +1,259 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+const testAPIKey = "super-secret-test-key"
+
+type recordedRequest struct {
+	Method string
+	Path   string
+	Query  string
+	APIKey string
+	Body   []byte
+}
+
+type recordingUpstream struct {
+	t        *testing.T
+	server   *httptest.Server
+	mu       sync.Mutex
+	requests []recordedRequest
+}
+
+func newRecordingUpstream(t *testing.T) *recordingUpstream {
+	t.Helper()
+	ru := &recordingUpstream{t: t}
+	ru.server = httptest.NewServer(http.HandlerFunc(ru.handle))
+	t.Cleanup(ru.server.Close)
+	return ru
+}
+
+func (ru *recordingUpstream) handle(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		ru.t.Errorf("read body: %v", err)
+	}
+	ru.mu.Lock()
+	ru.requests = append(ru.requests, recordedRequest{
+		Method: r.Method,
+		Path:   r.URL.Path,
+		Query:  r.URL.RawQuery,
+		APIKey: r.Header.Get("api-key"),
+		Body:   body,
+	})
+	ru.mu.Unlock()
+
+	if r.URL.Query().Get("api-version") != searchAPIVersion {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"bad api-version"}`))
+		return
+	}
+	if r.Header.Get("api-key") != testAPIKey {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"bad api-key"}`))
+		return
+	}
+
+	switch {
+	case r.Method == http.MethodPut && r.URL.Path == "/indexes/test-index":
+		w.WriteHeader(http.StatusCreated)
+	case r.Method == http.MethodPost && r.URL.Path == "/indexes/test-index/docs/index":
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"value":[{"key":"doc-1","status":true}]}`))
+	case r.Method == http.MethodPost && r.URL.Path == "/indexes/test-index/docs/search":
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"value":[{"id":"doc-1","content":"hello world"}]}`))
+	default:
+		w.WriteHeader(http.StatusNotFound)
+	}
+}
+
+func (ru *recordingUpstream) lastRequest(t *testing.T) recordedRequest {
+	t.Helper()
+	ru.mu.Lock()
+	defer ru.mu.Unlock()
+	if len(ru.requests) == 0 {
+		t.Fatal("expected at least one upstream request")
+	}
+	return ru.requests[len(ru.requests)-1]
+}
+
+func (ru *recordingUpstream) requestCount() int {
+	ru.mu.Lock()
+	defer ru.mu.Unlock()
+	return len(ru.requests)
+}
+
+func testClient(endpoint string) *SearchClient {
+	return NewSearchClient(endpoint, testAPIKey, "test-index", &http.Client{Timeout: 5 * time.Second})
+}
+
+func TestHealthzDoesNotCallUpstream(t *testing.T) {
+	ru := newRecordingUpstream(t)
+	handler := NewServer(testClient(ru.server.URL), log.New(io.Discard, "", 0))
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if strings.TrimSpace(rec.Body.String()) != `{"status":"ok"}` {
+		t.Fatalf("body = %q", rec.Body.String())
+	}
+	if got := ru.requestCount(); got != 0 {
+		t.Fatalf("upstream request count = %d, want 0", got)
+	}
+}
+
+func TestEnsureIndexIssuesCorrectPUT(t *testing.T) {
+	ru := newRecordingUpstream(t)
+	client := testClient(ru.server.URL)
+
+	if err := client.EnsureIndex(context.Background()); err != nil {
+		t.Fatalf("EnsureIndex() error = %v", err)
+	}
+
+	got := ru.lastRequest(t)
+	if got.Method != http.MethodPut {
+		t.Fatalf("method = %s, want PUT", got.Method)
+	}
+	if got.Path != "/indexes/test-index" {
+		t.Fatalf("path = %s", got.Path)
+	}
+	if got.Query != "api-version=2024-07-01" {
+		t.Fatalf("query = %s", got.Query)
+	}
+	if got.APIKey != testAPIKey {
+		t.Fatalf("api-key header = %q", got.APIKey)
+	}
+
+	var payload struct {
+		Name   string `json:"name"`
+		Fields []struct {
+			Name       string `json:"name"`
+			Type       string `json:"type"`
+			Key        bool   `json:"key"`
+			Searchable bool   `json:"searchable"`
+		} `json:"fields"`
+	}
+	if err := json.Unmarshal(got.Body, &payload); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if payload.Name != "test-index" || len(payload.Fields) != 2 {
+		t.Fatalf("unexpected index payload: %+v", payload)
+	}
+	if payload.Fields[0].Name != "id" || payload.Fields[0].Type != "Edm.String" || !payload.Fields[0].Key || payload.Fields[0].Searchable {
+		t.Fatalf("unexpected id field: %+v", payload.Fields[0])
+	}
+	if payload.Fields[1].Name != "content" || payload.Fields[1].Type != "Edm.String" || payload.Fields[1].Key || !payload.Fields[1].Searchable {
+		t.Fatalf("unexpected content field: %+v", payload.Fields[1])
+	}
+}
+
+func TestPostDocumentsForwardsMergeOrUpload(t *testing.T) {
+	ru := newRecordingUpstream(t)
+	handler := NewServer(testClient(ru.server.URL), log.New(io.Discard, "", 0))
+
+	req := httptest.NewRequest(http.MethodPost, "/documents", strings.NewReader(`{"id":"doc-1","content":"hello world"}`))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	got := ru.lastRequest(t)
+	if got.Method != http.MethodPost || got.Path != "/indexes/test-index/docs/index" || got.Query != "api-version=2024-07-01" {
+		t.Fatalf("unexpected upstream request: %+v", got)
+	}
+
+	var payload struct {
+		Value []map[string]string `json:"value"`
+	}
+	if err := json.Unmarshal(got.Body, &payload); err != nil {
+		t.Fatalf("unmarshal upload body: %v", err)
+	}
+	if len(payload.Value) != 1 || payload.Value[0]["@search.action"] != "mergeOrUpload" || payload.Value[0]["id"] != "doc-1" || payload.Value[0]["content"] != "hello world" {
+		t.Fatalf("unexpected upload body: %+v", payload)
+	}
+}
+
+func TestSearchForwardsQueryAndReturnsResults(t *testing.T) {
+	ru := newRecordingUpstream(t)
+	handler := NewServer(testClient(ru.server.URL), log.New(io.Discard, "", 0))
+
+	req := httptest.NewRequest(http.MethodGet, "/search?q=hello", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if strings.TrimSpace(rec.Body.String()) != `{"value":[{"id":"doc-1","content":"hello world"}]}` {
+		t.Fatalf("unexpected search response: %s", rec.Body.String())
+	}
+	got := ru.lastRequest(t)
+	if got.Method != http.MethodPost || got.Path != "/indexes/test-index/docs/search" || got.Query != "api-version=2024-07-01" {
+		t.Fatalf("unexpected upstream request: %+v", got)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(got.Body, &payload); err != nil {
+		t.Fatalf("unmarshal search body: %v", err)
+	}
+	if payload["search"] != "hello" {
+		t.Fatalf("search payload = %+v", payload)
+	}
+}
+
+func TestAPIKeyIsNotLoggedOrReturnedOnErrors(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"do not expose ` + testAPIKey + `"}`))
+	}))
+	defer upstream.Close()
+
+	var logs bytes.Buffer
+	handler := NewServer(testClient(upstream.URL), log.New(&logs, "", 0))
+
+	req := httptest.NewRequest(http.MethodPost, "/documents", strings.NewReader(`{"id":"doc-1","content":"hello"}`))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadGateway)
+	}
+	if strings.Contains(rec.Body.String(), testAPIKey) {
+		t.Fatalf("response exposed api key: %s", rec.Body.String())
+	}
+	if strings.Contains(logs.String(), testAPIKey) {
+		t.Fatalf("logs exposed api key: %s", logs.String())
+	}
+}
+
+func TestEnsureIndexErrorDoesNotContainAPIKey(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"` + testAPIKey + `"}`))
+	}))
+	defer upstream.Close()
+
+	err := testClient(upstream.URL).EnsureIndex(context.Background())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if strings.Contains(err.Error(), testAPIKey) {
+		t.Fatalf("error exposed api key: %v", err)
+	}
+}

--- a/samples/azure-search-api/src/search.go
+++ b/samples/azure-search-api/src/search.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const searchAPIVersion = "2024-07-01"
+
+// SearchClient is a small Azure AI Search REST client.
+type SearchClient struct {
+	endpoint   string
+	apiKey     string
+	indexName  string
+	httpClient *http.Client
+}
+
+// Document is the JSON payload accepted by POST /documents.
+type Document struct {
+	ID      string `json:"id"`
+	Content string `json:"content"`
+}
+
+func NewSearchClient(endpoint, apiKey, indexName string, httpClient *http.Client) *SearchClient {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	return &SearchClient{
+		endpoint:   strings.TrimRight(strings.TrimSpace(endpoint), "/"),
+		apiKey:     apiKey,
+		indexName:  indexName,
+		httpClient: httpClient,
+	}
+}
+
+func (c *SearchClient) EnsureIndex(ctx context.Context) error {
+	body := map[string]any{
+		"name": c.indexName,
+		"fields": []map[string]any{
+			{
+				"name":       "id",
+				"type":       "Edm.String",
+				"key":        true,
+				"searchable": false,
+			},
+			{
+				"name":       "content",
+				"type":       "Edm.String",
+				"searchable": true,
+			},
+		},
+	}
+
+	status, _, err := c.doJSON(ctx, http.MethodPut, "/indexes/"+url.PathEscape(c.indexName), body)
+	if err != nil {
+		return err
+	}
+	if status == http.StatusOK || status == http.StatusCreated || status == http.StatusNoContent {
+		return nil
+	}
+	return fmt.Errorf("ensure index failed: upstream returned HTTP %d", status)
+}
+
+func (c *SearchClient) UploadDocument(ctx context.Context, doc Document) error {
+	body := map[string]any{
+		"value": []map[string]any{
+			{
+				"@search.action": "mergeOrUpload",
+				"id":             doc.ID,
+				"content":        doc.Content,
+			},
+		},
+	}
+
+	status, _, err := c.doJSON(ctx, http.MethodPost, "/indexes/"+url.PathEscape(c.indexName)+"/docs/index", body)
+	if err != nil {
+		return err
+	}
+	if status != http.StatusOK {
+		return fmt.Errorf("upload document failed: upstream returned HTTP %d", status)
+	}
+	return nil
+}
+
+func (c *SearchClient) Search(ctx context.Context, query string) ([]byte, error) {
+	body := map[string]string{"search": query}
+	status, responseBody, err := c.doJSON(ctx, http.MethodPost, "/indexes/"+url.PathEscape(c.indexName)+"/docs/search", body)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("search failed: upstream returned HTTP %d", status)
+	}
+	return responseBody, nil
+}
+
+func (c *SearchClient) doJSON(ctx context.Context, method, path string, payload any) (int, []byte, error) {
+	if c.endpoint == "" {
+		return 0, nil, errors.New("search endpoint is not configured")
+	}
+	if c.apiKey == "" {
+		return 0, nil, errors.New("search api key is not configured")
+	}
+	if c.indexName == "" {
+		return 0, nil, errors.New("search index name is not configured")
+	}
+
+	requestURL, err := c.url(path)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(payload); err != nil {
+		return 0, nil, fmt.Errorf("encode search request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, requestURL, &body)
+	if err != nil {
+		return 0, nil, fmt.Errorf("create search request: %w", err)
+	}
+	req.Header.Set("api-key", c.apiKey)
+	req.Header.Set("accept", "application/json")
+	req.Header.Set("content-type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, nil, fmt.Errorf("call search service: %w", err)
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return resp.StatusCode, nil, fmt.Errorf("read search response: %w", err)
+	}
+	return resp.StatusCode, responseBody, nil
+}
+
+func (c *SearchClient) url(path string) (string, error) {
+	u, err := url.Parse(c.endpoint)
+	if err != nil {
+		return "", fmt.Errorf("parse search endpoint: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return "", errors.New("search endpoint must be an absolute URL")
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + path
+	q := u.Query()
+	q.Set("api-version", searchAPIVersion)
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}

--- a/samples/berriai-litellm/README.md
+++ b/samples/berriai-litellm/README.md
@@ -1,0 +1,34 @@
+# LiteLLM proxy + Radius.AI/models (Azure OpenAI)
+
+This sample provisions an Azure OpenAI account and chat deployment through `Radius.AI/models` using an Azure Verified Module (AVM) recipe. It builds and runs LiteLLM as a proxy that exposes the model through a local OpenAI-compatible endpoint.
+
+## What this sample shows
+- **Resource type:** `Radius.AI/models`
+- **Cloud backing (Azure):** Azure OpenAI via the AVM `mcr.microsoft.com/bicep/avm/res/cognitive-services/account:0.15.0` module (`env-azure.bicep`).
+- **Application:** LiteLLM `v1.91.0`, built from source via `Radius.Compute/containerImages` and run via `imageReference`.
+- **Credential model:** The recipe exposes the API key under nested `outputs.secrets.apiKey`. The app reads the non-secret `model.properties.endpoint` directly and consumes the key as `AZURE_API_KEY` via a `secretKeyRef` backed by `model.properties.secrets`.
+
+## Files
+| File | Role |
+| --- | --- |
+| `app.bicep` | Developer view: the Radius application, model resource, LiteLLM image build, and LiteLLM container. |
+| `env-azure.bicep` | Platform-engineer view: the `recipePacks` binding the type to the AVM module plus supporting recipes, and the `environment`. |
+| `bicepconfig.json` | Radius Bicep extension configuration. |
+
+## Deploying
+Deploy `env-azure.bicep` (the environment) first, then `app.bicep`.
+
+This sample builds its container image from source with a `Radius.Compute/containerImages` recipe and pushes it to a registry you supply. When deploying `env-azure.bicep`, provide:
+- `containerImagesRegistry` — an OCI registry you can push to (e.g. `ghcr.io/your-org`).
+- `containerImagesRegistrySecretName` — the name of a Kubernetes Secret (`username`/`password`) in the environment namespace, used to authenticate the BuildKit **push** of the built image. Create it before deploying.
+
+Image **pull** auth is separate: the `containerImages` recipe does not configure kubelet pull credentials, so the built image repository must be publicly readable by the cluster, or you must configure a Kubernetes image-pull secret (e.g. a `kubernetes.io/dockerconfigjson` `imagePullSecret` on the namespace's `default` ServiceAccount) before deploying `app.bicep` — otherwise the app pods fail with `ImagePullBackOff`.
+
+## Notes
+The LiteLLM container writes a minimal config at startup, maps the Azure OpenAI deployment to model name `chat`, and listens on port 4000. It uses Azure OpenAI API version `2025-04-01-preview` and sets a sample `LITELLM_MASTER_KEY`.
+
+The model resource requests `gpt-5-mini`; the environment recipe creates the matching Azure OpenAI deployment named `chat`. Override the Azure account name with the environment parameter required by your deployment flow.
+
+Additional deployment details:
+- The container exposes the LiteLLM proxy on port 4000.
+- The image build uses the upstream LiteLLM repository at tag `v1.91.0`.

--- a/samples/berriai-litellm/app.bicep
+++ b/samples/berriai-litellm/app.bicep
@@ -1,0 +1,91 @@
+extension radius
+
+@description('The ID of your Radius Environment. Set automatically by the rad CLI.')
+param environment string
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'llm-azure-app-test'
+  properties: {
+    environment: environment
+  }
+}
+
+resource model 'Radius.AI/models@2025-08-01-preview' = {
+  name: 'model'
+  properties: {
+    environment: environment
+    application: app.id
+    model: 'gpt-5-mini'
+  }
+}
+
+resource litellmImage 'Radius.Compute/containerImages@2025-08-01-preview' = {
+  name: 'litellm-image'
+  properties: {
+    environment: environment
+    application: app.id
+    tag: 'v1.91.0'
+    build: {
+      source: 'git::https://github.com/BerriAI/litellm.git//?ref=v1.91.0'
+    }
+  }
+}
+
+resource litellmctr 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'litellmctr'
+  properties: {
+    environment: environment
+    application: app.id
+    containers: {
+      litellm: {
+        image: litellmImage.properties.imageReference
+        command: [
+          '/bin/sh'
+          '-c'
+          '''
+set -eu
+cat > /tmp/litellm.config.yaml <<'EOF'
+model_list:
+  - model_name: chat
+    litellm_params:
+      model: azure/chat
+      api_base: os.environ/AZURE_API_BASE
+      api_key: os.environ/AZURE_API_KEY
+      api_version: os.environ/AZURE_API_VERSION
+EOF
+exec litellm --config /tmp/litellm.config.yaml --host 0.0.0.0 --port 4000
+'''
+        ]
+        ports: {
+          web: {
+            containerPort: 4000
+          }
+        }
+        env: {
+          AZURE_API_BASE: {
+            value: model.properties.endpoint
+          }
+          AZURE_API_KEY: {
+            valueFrom: {
+              secretKeyRef: {
+                secretName: model.properties.secrets.name
+                key: 'apiKey'
+              }
+            }
+          }
+          AZURE_API_VERSION: {
+            value: '2025-04-01-preview'
+          }
+          LITELLM_MASTER_KEY: {
+            value: 'sk-radius-verify'
+          }
+        }
+      }
+    }
+    connections: {
+      model: {
+        source: model.id
+      }
+    }
+  }
+}

--- a/samples/berriai-litellm/bicepconfig.json
+++ b/samples/berriai-litellm/bicepconfig.json
@@ -1,0 +1,8 @@
+{
+  "experimentalFeaturesEnabled": {
+    "extensibility": true
+  },
+  "extensions": {
+    "radius": "br:biceptypes.azurecr.io/radius:latest"
+  }
+}

--- a/samples/berriai-litellm/env-azure.bicep
+++ b/samples/berriai-litellm/env-azure.bicep
@@ -1,0 +1,103 @@
+extension radius
+
+@description('Azure subscription ID the environment provisions resources into.')
+param azureSubscriptionId string
+
+@description('Azure resource group the environment provisions resources into. Must already exist.')
+param azureResourceGroup string
+
+@description('Globally-unique Azure OpenAI account name (2-64 alphanumerics/hyphens). The workflow generates a unique value per run.')
+param accountName string
+
+@description('OCI ref for the Radius.Compute/containers recipe. Override to a custom build if needed; defaults to the released public recipe.')
+param containersRecipe string = 'ghcr.io/radius-project/kube-recipes/containers:latest'
+
+@description('OCI registry the containerImages recipe builds and pushes the LiteLLM image to (e.g. `ghcr.io/myorg`).')
+param containerImagesRegistry string
+
+@description('Kubernetes Secret (in the environment namespace) holding the push registry `username`/`password`.')
+param containerImagesRegistrySecretName string
+
+resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
+  name: 'llm-azure-avm'
+  properties: {
+    recipes: {
+      'Radius.AI/models': {
+        kind: 'bicep'
+
+        source: 'mcr.microsoft.com/bicep/avm/res/cognitive-services/account:0.15.0'
+        parameters: {
+          name: accountName
+          kind: 'OpenAI'
+          sku: 'S0'
+          customSubDomainName: accountName
+
+          disableLocalAuth: false
+
+          publicNetworkAccess: 'Enabled'
+          deployments: [
+            {
+              name: 'chat'
+              model: {
+                format: 'OpenAI'
+                name: '{{context.resource.properties.model}}'
+                version: '2025-08-07'
+              }
+              sku: {
+                name: 'GlobalStandard'
+                capacity: 1
+              }
+            }
+          ]
+
+          enableTelemetry: false
+        }
+
+        outputs: {
+          endpoint: 'endpoint'
+          secrets: {
+            apiKey: 'primaryKey'
+          }
+        }
+      }
+
+      'Radius.Compute/containers': {
+        kind: 'bicep'
+        source: containersRecipe
+      }
+
+      'Radius.Compute/containerImages': {
+        kind: 'terraform'
+        source: 'git::https://github.com/radius-project/resource-types-contrib.git//Compute/containerImages/recipes/kubernetes/terraform?ref=b9e0fad536a53349b98f94c5be961db84845e1b7'
+        parameters: {
+          registry: containerImagesRegistry
+          registrySecretName: containerImagesRegistrySecretName
+        }
+      }
+
+      'Radius.Security/secrets': {
+        kind: 'bicep'
+        source: 'ghcr.io/radius-project/kube-recipes/secrets:latest'
+      }
+    }
+  }
+}
+
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
+  name: 'azure'
+  properties: {
+    providers: {
+      azure: {
+        subscriptionId: azureSubscriptionId
+        resourceGroupName: azureResourceGroup
+      }
+
+      kubernetes: {
+        namespace: 'default'
+      }
+    }
+    recipePacks: [
+      recipes.id
+    ]
+  }
+}

--- a/samples/dockersamples-todo-list-app/README.md
+++ b/samples/dockersamples-todo-list-app/README.md
@@ -1,0 +1,32 @@
+# Docker todo-list-app + Radius.Data/mySqlDatabases (Azure MySQL)
+
+This sample provisions an Azure Database for MySQL flexible server and database through `Radius.Data/mySqlDatabases` using an Azure Verified Module (AVM) recipe. It builds and runs Docker's getting-started todo-list-app against that MySQL database.
+
+## What this sample shows
+- **Resource type:** `Radius.Data/mySqlDatabases`
+- **Cloud backing (Azure):** Azure Database for MySQL via the AVM `mcr.microsoft.com/bicep/avm/res/db-for-my-sql/flexible-server:0.10.3` module (`env-azure.bicep`).
+- **Application:** Docker getting-started todo-list-app `v1.0.0` from commit `55680777bc46c59d3fe0ab9ff7e79ee947d0c757`, built from source via `Radius.Compute/containerImages` and run via `imageReference`.
+- **Credential model:** A developer-authored secure `password` parameter is set on the MySQL resource and reused by the app as `MYSQL_PASSWORD`.
+
+## Files
+| File | Role |
+| --- | --- |
+| `app.bicep` | Developer view: the Radius application, MySQL database resource, todo app image build, and todo app container. |
+| `env-azure.bicep` | Platform-engineer view: the `recipePacks` binding the type to the AVM module plus supporting recipes, and the `environment`. |
+| `bicepconfig.json` | Radius Bicep extension configuration. |
+
+## Deploying
+Deploy `env-azure.bicep` (the environment) first, then `app.bicep`.
+
+This sample builds its container image from source with a `Radius.Compute/containerImages` recipe and pushes it to a registry you supply. When deploying `env-azure.bicep`, provide:
+- `containerImagesRegistry` — an OCI registry you can push to (e.g. `ghcr.io/your-org`).
+- `containerImagesRegistrySecretName` — the name of a Kubernetes Secret (`username`/`password`) in the environment namespace, used to authenticate the BuildKit **push** of the built image. Create it before deploying.
+
+Image **pull** auth is separate: the `containerImages` recipe does not configure kubelet pull credentials, so the built image repository must be publicly readable by the cluster, or you must configure a Kubernetes image-pull secret (e.g. a `kubernetes.io/dockerconfigjson` `imagePullSecret` on the namespace's `default` ServiceAccount) before deploying `app.bicep` — otherwise the app pods fail with `ImagePullBackOff`.
+
+Provide the database admin `password` parameter when deploying `app.bicep`.
+
+## Notes
+The MySQL recipe creates database `appdb`, admin user `radadmin`, and a firewall rule for the supplied client egress IP. The sample disables MySQL `require_secure_transport` so the todo app can connect with its standard MySQL settings.
+
+The todo app listens on port 3000 and receives `MYSQL_HOST`, `MYSQL_DB`, `MYSQL_USER`, and `MYSQL_PASSWORD` from `app.bicep`. The Radius database resource uses MySQL version `8.0`.

--- a/samples/dockersamples-todo-list-app/app.bicep
+++ b/samples/dockersamples-todo-list-app/app.bicep
@@ -1,0 +1,75 @@
+extension radius
+@description('The ID of your Radius Environment. Set automatically by the rad CLI.')
+param environment string
+
+@description('Database admin password. Marked @secure(); Radius encrypts it and injects it into the recipe and the container.')
+@secure()
+param password string
+
+var databaseName = 'appdb'
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'mysql-azure-app-test'
+  properties: {
+    environment: environment
+  }
+}
+
+resource mysql 'Radius.Data/mySqlDatabases@2025-08-01-preview' = {
+  name: 'mysql'
+  properties: {
+    environment: environment
+    application: app.id
+    version: '8.0'
+    database: databaseName
+
+    username: 'radadmin'
+    password: password
+  }
+}
+
+resource todoAppImage 'Radius.Compute/containerImages@2025-08-01-preview' = {
+  name: 'todo-app-image'
+  properties: {
+    environment: environment
+    application: app.id
+
+    tag: 'v1.0.0'
+    build: {
+      source: 'git::https://github.com/docker/getting-started-todo-app.git//?ref=55680777bc46c59d3fe0ab9ff7e79ee947d0c757'
+    }
+  }
+}
+
+resource todoctr 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'todoctr'
+  properties: {
+    environment: environment
+    application: app.id
+    containers: {
+      todo: {
+        image: todoAppImage.properties.imageReference
+        ports: {
+          web: {
+            containerPort: 3000
+          }
+        }
+        env: {
+          MYSQL_HOST: {
+            value: mysql.properties.host
+          }
+          MYSQL_DB: {
+            value: databaseName
+          }
+
+          MYSQL_USER: {
+            value: 'radadmin'
+          }
+          MYSQL_PASSWORD: {
+            value: password
+          }
+        }
+      }
+    }
+  }
+}

--- a/samples/dockersamples-todo-list-app/bicepconfig.json
+++ b/samples/dockersamples-todo-list-app/bicepconfig.json
@@ -1,0 +1,8 @@
+{
+  "experimentalFeaturesEnabled": {
+    "extensibility": true
+  },
+  "extensions": {
+    "radius": "br:biceptypes.azurecr.io/radius:latest"
+  }
+}

--- a/samples/dockersamples-todo-list-app/env-azure.bicep
+++ b/samples/dockersamples-todo-list-app/env-azure.bicep
@@ -1,0 +1,115 @@
+extension radius
+
+@description('Azure subscription ID the environment provisions resources into.')
+param azureSubscriptionId string
+
+@description('Azure resource group the environment provisions resources into. Must already exist.')
+param azureResourceGroup string
+
+@description('Globally-unique MySQL flexible server name (3-63 lowercase alphanumerics/hyphens). The workflow generates a unique value per run.')
+param serverName string
+
+@description('Public IP allowed through the flexible server firewall — the CI runner egress IP, which the in-cluster app container also NATs through. The verify workflow computes it at provision time.')
+param clientIpAddress string
+
+@description('OCI ref for the Radius.Compute/containers recipe. Override to a custom build if needed; defaults to the released public recipe.')
+param containersRecipe string = 'ghcr.io/radius-project/kube-recipes/containers:latest'
+
+@description('OCI registry the containerImages recipe builds and pushes the todo-app image to (e.g. `ghcr.io/myorg`).')
+param containerImagesRegistry string
+
+@description('Kubernetes Secret (in the environment namespace) holding the push registry `username`/`password`.')
+param containerImagesRegistrySecretName string
+
+resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
+  name: 'mysql-azure-app-avm'
+  properties: {
+    recipes: {
+      'Radius.Data/mySqlDatabases': {
+        kind: 'bicep'
+
+        source: 'mcr.microsoft.com/bicep/avm/res/db-for-my-sql/flexible-server:0.10.3'
+        parameters: {
+          name: serverName
+
+          administratorLogin: '{{context.resource.properties.username}}'
+          administratorLoginPassword: '{{context.resource.properties.password}}'
+
+          skuName: 'Standard_B1ms'
+          tier: 'Burstable'
+
+          version: '{{context.resource.properties.version == "5.7" ? "5.7" : "8.0.21"}}'
+
+          databases: [
+            {
+              name: '{{context.resource.properties.database}}'
+            }
+          ]
+
+          firewallRules: [
+            {
+              name: 'e2e-runner'
+              startIpAddress: clientIpAddress
+              endIpAddress: clientIpAddress
+            }
+          ]
+
+          configurations: [
+            {
+              name: 'require_secure_transport'
+              source: 'user-override'
+              value: 'OFF'
+            }
+          ]
+
+          availabilityZone: -1
+
+          highAvailability: 'Disabled'
+          geoRedundantBackup: 'Disabled'
+          storageSizeGB: 32
+
+          publicNetworkAccess: 'Enabled'
+
+          enableTelemetry: false
+        }
+
+        outputs: {
+          host: 'fqdn'
+        }
+      }
+
+      'Radius.Compute/containers': {
+        kind: 'bicep'
+        source: containersRecipe
+      }
+
+      'Radius.Compute/containerImages': {
+        kind: 'terraform'
+        source: 'git::https://github.com/radius-project/resource-types-contrib.git//Compute/containerImages/recipes/kubernetes/terraform?ref=b9e0fad536a53349b98f94c5be961db84845e1b7'
+        parameters: {
+          registry: containerImagesRegistry
+          registrySecretName: containerImagesRegistrySecretName
+        }
+      }
+    }
+  }
+}
+
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
+  name: 'azure'
+  properties: {
+    providers: {
+      azure: {
+        subscriptionId: azureSubscriptionId
+        resourceGroupName: azureResourceGroup
+      }
+
+      kubernetes: {
+        namespace: 'default'
+      }
+    }
+    recipePacks: [
+      recipes.id
+    ]
+  }
+}

--- a/samples/drakkan-sftpgo/README.md
+++ b/samples/drakkan-sftpgo/README.md
@@ -1,0 +1,34 @@
+# SFTPGo + Radius.Storage/objectStorage (Azure Blob Storage)
+
+This sample provisions an Azure Storage account and blob container through `Radius.Storage/objectStorage` using an Azure Verified Module (AVM) recipe. It builds and runs SFTPGo with an SFTP user backed by the provisioned Blob Storage container.
+
+## What this sample shows
+- **Resource type:** `Radius.Storage/objectStorage`
+- **Cloud backing (Azure):** Azure Blob Storage via the AVM `mcr.microsoft.com/bicep/avm/res/storage/storage-account:0.32.1` module (`env-azure.bicep`).
+- **Application:** SFTPGo `v2.7.4`, built from source via `Radius.Compute/containerImages` and run via `imageReference`.
+- **Credential model:** The recipe exposes the storage account key under nested `outputs.secrets.accountKey`. The app reads the non-secret `store.properties.accountName` and `store.properties.containerName` directly and consumes the key as `AZ_KEY` via a `secretKeyRef` backed by `store.properties.secrets`, to initialize the SFTPGo Azure Blob filesystem.
+
+## Files
+| File | Role |
+| --- | --- |
+| `app.bicep` | Developer view: the Radius application, object storage resource, SFTPGo image build, and SFTPGo container. |
+| `env-azure.bicep` | Platform-engineer view: the `recipePacks` binding the type to the AVM module plus supporting recipes, and the `environment`. |
+| `bicepconfig.json` | Radius Bicep extension configuration. |
+
+## Deploying
+Deploy `env-azure.bicep` (the environment) first, then `app.bicep`.
+
+This sample builds its container image from source with a `Radius.Compute/containerImages` recipe and pushes it to a registry you supply. When deploying `env-azure.bicep`, provide:
+- `containerImagesRegistry` — an OCI registry you can push to (e.g. `ghcr.io/your-org`).
+- `containerImagesRegistrySecretName` — the name of a Kubernetes Secret (`username`/`password`) in the environment namespace, used to authenticate the BuildKit **push** of the built image. Create it before deploying.
+
+Image **pull** auth is separate: the `containerImages` recipe does not configure kubelet pull credentials, so the built image repository must be publicly readable by the cluster, or you must configure a Kubernetes image-pull secret (e.g. a `kubernetes.io/dockerconfigjson` `imagePullSecret` on the namespace's `default` ServiceAccount) before deploying `app.bicep` — otherwise the app pods fail with `ImagePullBackOff`.
+
+## Notes
+SFTPGo uses an in-memory data provider and loads a generated `init.json` at startup. The sample exposes SFTP on port 2022 and the HTTP UI on port 8080, creates an admin user, and creates a `radius` user whose home directory maps to the Azure Blob container.
+
+The object storage recipe creates a `Standard_LRS` StorageV2 account and a blob container named `data`. Blob public access is disabled, while network ACLs allow access for this sample.
+
+Additional deployment details:
+- The app declares a `connections.store` relationship to the object storage resource.
+- The image build uses the upstream SFTPGo repository at tag `v2.7.4`.

--- a/samples/drakkan-sftpgo/app.bicep
+++ b/samples/drakkan-sftpgo/app.bicep
@@ -1,0 +1,100 @@
+extension radius
+@description('The ID of your Radius Environment. Set automatically by the rad CLI.')
+param environment string
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'storage-azure-app-test'
+  properties: {
+    environment: environment
+  }
+}
+
+resource sftpgoImage 'Radius.Compute/containerImages@2025-08-01-preview' = {
+  name: 'sftpgo-image'
+  properties: {
+    environment: environment
+    application: app.id
+
+    tag: 'v2.7.4'
+    build: {
+      source: 'git::https://github.com/drakkan/sftpgo.git//?ref=v2.7.4'
+    }
+  }
+}
+
+resource store 'Radius.Storage/objectStorage@2025-08-01-preview' = {
+  name: 'store'
+  properties: {
+    environment: environment
+    application: app.id
+
+    containerName: 'data'
+  }
+}
+
+resource sftpgoctr 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'sftpgoctr'
+  properties: {
+    environment: environment
+    application: app.id
+    containers: {
+      sftpgo: {
+        image: sftpgoImage.properties.imageReference
+
+        command: [
+          '/bin/sh'
+          '-c'
+          '''
+set -eu
+cat > /var/lib/sftpgo/init.json <<EOF
+{"admins":[{"username":"admin","password":"radius-verify-Admin1!","status":1,"permissions":["*"]}],"users":[{"username":"radius","password":"radius-verify-Pass1!","status":1,"permissions":{"/":["*"]},"home_dir":"/srv/sftpgo/data/radius","filesystem":{"provider":3,"azblobconfig":{"container":"$AZ_CONTAINER","account_name":"$AZ_ACCOUNT","account_key":{"status":"Plain","payload":"$AZ_KEY"}}}}]}
+EOF
+exec sftpgo serve
+'''
+        ]
+        ports: {
+          sftp: {
+            containerPort: 2022
+          }
+
+          http: {
+            containerPort: 8080
+          }
+        }
+        env: {
+          SFTPGO_DATA_PROVIDER__DRIVER: {
+            value: 'memory'
+          }
+          SFTPGO_LOADDATA_FROM: {
+            value: '/var/lib/sftpgo/init.json'
+          }
+
+          SFTPGO_LOG_FILE_PATH: {
+            value: ''
+          }
+
+          AZ_ACCOUNT: {
+            value: store.properties.accountName
+          }
+          AZ_KEY: {
+            valueFrom: {
+              secretKeyRef: {
+                secretName: store.properties.secrets.name
+                key: 'accountKey'
+              }
+            }
+          }
+          AZ_CONTAINER: {
+            value: store.properties.containerName
+          }
+        }
+      }
+    }
+
+    connections: {
+      store: {
+        source: store.id
+      }
+    }
+  }
+}

--- a/samples/drakkan-sftpgo/bicepconfig.json
+++ b/samples/drakkan-sftpgo/bicepconfig.json
@@ -1,0 +1,8 @@
+{
+  "experimentalFeaturesEnabled": {
+    "extensibility": true
+  },
+  "extensions": {
+    "radius": "br:biceptypes.azurecr.io/radius:latest"
+  }
+}

--- a/samples/drakkan-sftpgo/env-azure.bicep
+++ b/samples/drakkan-sftpgo/env-azure.bicep
@@ -1,0 +1,102 @@
+extension radius
+
+@description('Azure subscription ID the environment provisions resources into.')
+param azureSubscriptionId string
+
+@description('Azure resource group the environment provisions resources into. Must already exist.')
+param azureResourceGroup string
+
+@description('Globally-unique Azure Storage account name (3-24 lowercase letters/numbers, no hyphens). The workflow generates a unique value per run.')
+param uniqueName string
+
+@description('OCI ref for the Radius.Compute/containers recipe. Override to a custom build if needed; defaults to the released public recipe.')
+param containersRecipe string = 'ghcr.io/radius-project/kube-recipes/containers:latest'
+
+@description('OCI registry the containerImages recipe builds and pushes the sftpgo image to (e.g. `ghcr.io/myorg`).')
+param containerImagesRegistry string
+
+@description('Kubernetes Secret (in the environment namespace) holding the push registry `username`/`password`.')
+param containerImagesRegistrySecretName string
+
+resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
+  name: 'storage-azure-avm'
+  properties: {
+    recipes: {
+      'Radius.Storage/objectStorage': {
+        kind: 'bicep'
+
+        source: 'mcr.microsoft.com/bicep/avm/res/storage/storage-account:0.32.1'
+        parameters: {
+          name: uniqueName
+
+          kind: 'StorageV2'
+          skuName: 'Standard_LRS'
+
+          allowBlobPublicAccess: false
+
+          networkAcls: {
+            bypass: 'AzureServices'
+            defaultAction: 'Allow'
+          }
+
+          blobServices: {
+            containers: [
+              {
+                name: '{{context.resource.properties.containerName}}'
+              }
+            ]
+          }
+
+          enableTelemetry: false
+        }
+
+        outputs: {
+          endpoint: 'primaryBlobEndpoint'
+          accountName: 'name'
+          secrets: {
+            connectionString: 'primaryConnectionString'
+            accountKey: 'primaryAccessKey'
+          }
+        }
+      }
+
+      'Radius.Security/secrets': {
+        kind: 'bicep'
+        source: 'ghcr.io/radius-project/kube-recipes/secrets:latest'
+      }
+
+      'Radius.Compute/containers': {
+        kind: 'bicep'
+        source: containersRecipe
+      }
+
+      'Radius.Compute/containerImages': {
+        kind: 'terraform'
+        source: 'git::https://github.com/radius-project/resource-types-contrib.git//Compute/containerImages/recipes/kubernetes/terraform?ref=7f5375bf89305d7641ff645336841618b305daf8'
+        parameters: {
+          registry: containerImagesRegistry
+          registrySecretName: containerImagesRegistrySecretName
+        }
+      }
+    }
+  }
+}
+
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
+  name: 'azure'
+  properties: {
+    providers: {
+      azure: {
+        subscriptionId: azureSubscriptionId
+        resourceGroupName: azureResourceGroup
+      }
+
+      kubernetes: {
+        namespace: 'default'
+      }
+    }
+    recipePacks: [
+      recipes.id
+    ]
+  }
+}

--- a/samples/kafka-ui/README.md
+++ b/samples/kafka-ui/README.md
@@ -1,0 +1,30 @@
+# Kafbat Kafka UI + Radius.Messaging/kafka (Azure Event Hubs)
+
+This sample provisions a Kafka-compatible Azure Event Hubs namespace and event hub through `Radius.Messaging/kafka` using an Azure Verified Module (AVM) recipe. It runs Kafbat Kafka UI against that broker so you can inspect the provisioned topic from a web UI.
+
+## What this sample shows
+- **Resource type:** `Radius.Messaging/kafka`
+- **Cloud backing (Azure):** Azure Event Hubs via the AVM `mcr.microsoft.com/bicep/avm/res/event-hub/namespace:0.14.2` module (`env-azure.bicep`).
+- **Application:** Kafbat Kafka UI `ghcr.io/kafbat/kafka-ui:v1.5.0`, run from a pinned published image.
+- **Credential model:** The recipe exposes the broker connection string under nested `outputs.secrets.connectionString`. The app consumes it as `RAD_SECRET_CONNECTIONSTRING` via a `secretKeyRef` backed by `kafkaBroker.properties.secrets`; the Kafka JAAS config then references it with Kubernetes `$(RAD_SECRET_CONNECTIONSTRING)` substitution.
+
+## Files
+| File | Role |
+| --- | --- |
+| `app.bicep` | Developer view: the Radius application, Kafka resource, and Kafka UI container. |
+| `env-azure.bicep` | Platform-engineer view: the `recipePacks` binding the type to the AVM module plus supporting recipes, and the `environment`. |
+| `bicepconfig.json` | Radius Bicep extension configuration. |
+
+## Deploying
+Deploy `env-azure.bicep` (the environment) first, then `app.bicep`.
+
+## Notes
+Kafka UI connects to Event Hubs over Kafka protocol on port 9093 with `SASL_SSL` and `PLAIN` authentication.
+
+This is the only sample in this set that does not build its app image from source. It uses the official published image because building a Kafka UI from source is impractical for a small sample: Kafbat, AKHQ, and Kafdrop Dockerfiles require prebuilt JARs, and Redpanda Console has no production Dockerfile.
+
+The Event Hubs recipe creates the `events` event hub from the Radius resource's `topic` property. The environment also includes the standard containers and secrets recipes used by the app container.
+
+Additional deployment details:
+- The Kafka UI container exposes web port 8080.
+- The broker host is combined with `.servicebus.windows.net:9093`.

--- a/samples/kafka-ui/app.bicep
+++ b/samples/kafka-ui/app.bicep
@@ -1,0 +1,71 @@
+extension radius
+
+@description('The ID of your Radius Environment. Set automatically by the rad CLI.')
+param environment string
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'kafka-azure-test'
+  properties: {
+    environment: environment
+  }
+}
+
+resource kafkaBroker 'Radius.Messaging/kafka@2025-08-01-preview' = {
+  name: 'kafka'
+  properties: {
+    environment: environment
+    application: app.id
+    topic: 'events'
+  }
+}
+
+resource kafkauictr 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'kafkauictr'
+  properties: {
+    environment: environment
+    application: app.id
+    containers: {
+      kafkaui: {
+        image: 'ghcr.io/kafbat/kafka-ui:v1.5.0'
+        ports: {
+          web: {
+            containerPort: 8080
+          }
+        }
+        env: {
+          KAFKA_CLUSTERS_0_NAME: {
+            value: 'event-hubs'
+          }
+
+          KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: {
+            value: '${kafkaBroker.properties.host}.servicebus.windows.net:9093'
+          }
+          KAFKA_CLUSTERS_0_PROPERTIES_SECURITY_PROTOCOL: {
+            value: 'SASL_SSL'
+          }
+          KAFKA_CLUSTERS_0_PROPERTIES_SASL_MECHANISM: {
+            value: 'PLAIN'
+          }
+
+          RAD_SECRET_CONNECTIONSTRING: {
+            valueFrom: {
+              secretKeyRef: {
+                secretName: kafkaBroker.properties.secrets.name
+                key: 'connectionString'
+              }
+            }
+          }
+
+          KAFKA_CLUSTERS_0_PROPERTIES_SASL_JAAS_CONFIG: {
+            value: 'org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password="$(RAD_SECRET_CONNECTIONSTRING)";'
+          }
+        }
+      }
+    }
+    connections: {
+      kafka: {
+        source: kafkaBroker.id
+      }
+    }
+  }
+}

--- a/samples/kafka-ui/bicepconfig.json
+++ b/samples/kafka-ui/bicepconfig.json
@@ -1,0 +1,8 @@
+{
+  "experimentalFeaturesEnabled": {
+    "extensibility": true
+  },
+  "extensions": {
+    "radius": "br:biceptypes.azurecr.io/radius:latest"
+  }
+}

--- a/samples/kafka-ui/env-azure.bicep
+++ b/samples/kafka-ui/env-azure.bicep
@@ -1,0 +1,78 @@
+extension radius
+
+@description('Azure subscription ID the environment provisions resources into.')
+param azureSubscriptionId string
+
+@description('Azure resource group the environment provisions resources into. Must already exist.')
+param azureResourceGroup string
+
+@description('Globally-unique Azure Event Hubs namespace name (6-50 alphanumerics/hyphens, starts with a letter). The workflow generates a unique value per run.')
+param namespaceName string
+
+@description('OCI ref for the Radius.Compute/containers recipe. Override to a custom build if needed; defaults to the released public recipe.')
+param containersRecipe string = 'ghcr.io/radius-project/kube-recipes/containers:latest'
+
+resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
+  name: 'kafka-azure-avm'
+  properties: {
+    recipes: {
+      'Radius.Messaging/kafka': {
+        kind: 'bicep'
+
+        source: 'mcr.microsoft.com/bicep/avm/res/event-hub/namespace:0.14.2'
+        parameters: {
+          name: namespaceName
+
+          skuName: 'Standard'
+          skuCapacity: 1
+
+          disableLocalAuth: false
+
+          eventhubs: [
+            {
+              name: '{{context.resource.properties.topic}}'
+            }
+          ]
+
+          enableTelemetry: false
+        }
+
+        outputs: {
+          host: 'name'
+          secrets: {
+            connectionString: 'primaryConnectionString'
+          }
+        }
+      }
+
+      'Radius.Compute/containers': {
+        kind: 'bicep'
+        source: containersRecipe
+      }
+
+      'Radius.Security/secrets': {
+        kind: 'bicep'
+        source: 'ghcr.io/radius-project/kube-recipes/secrets:latest'
+      }
+    }
+  }
+}
+
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
+  name: 'azure'
+  properties: {
+    providers: {
+      azure: {
+        subscriptionId: azureSubscriptionId
+        resourceGroupName: azureResourceGroup
+      }
+
+      kubernetes: {
+        namespace: 'default'
+      }
+    }
+    recipePacks: [
+      recipes.id
+    ]
+  }
+}

--- a/samples/mongo-express-mongo-express/README.md
+++ b/samples/mongo-express-mongo-express/README.md
@@ -1,0 +1,34 @@
+# mongo-express + Radius.Data/mongoDatabases (Azure Cosmos DB for MongoDB)
+
+This sample provisions a MongoDB-compatible Azure Cosmos DB account and database through `Radius.Data/mongoDatabases` using an Azure Verified Module (AVM) recipe. It builds and runs mongo-express as a browser UI for the provisioned database.
+
+## What this sample shows
+- **Resource type:** `Radius.Data/mongoDatabases`
+- **Cloud backing (Azure):** Azure Cosmos DB for MongoDB via the AVM `mcr.microsoft.com/bicep/avm/res/document-db/database-account:0.19.0` module (`env-azure.bicep`).
+- **Application:** mongo-express `v1.0.2`, built from source via `Radius.Compute/containerImages` and run via `imageReference`.
+- **Credential model:** The recipe exposes the database connection string under nested `outputs.secrets.connectionString`. The app consumes it as `ME_CONFIG_MONGODB_URL` via a `secretKeyRef` backed by `mongo.properties.secrets` and declares a `connections.mongo` relationship.
+
+## Files
+| File | Role |
+| --- | --- |
+| `app.bicep` | Developer view: the Radius application, Mongo database resource, mongo-express image build, and mongo-express container. |
+| `env-azure.bicep` | Platform-engineer view: the `recipePacks` binding the type to the AVM module plus supporting recipes, and the `environment`. |
+| `bicepconfig.json` | Radius Bicep extension configuration. |
+
+## Deploying
+Deploy `env-azure.bicep` (the environment) first, then `app.bicep`.
+
+This sample builds its container image from source with a `Radius.Compute/containerImages` recipe and pushes it to a registry you supply. When deploying `env-azure.bicep`, provide:
+- `containerImagesRegistry` — an OCI registry you can push to (e.g. `ghcr.io/your-org`).
+- `containerImagesRegistrySecretName` — the name of a Kubernetes Secret (`username`/`password`) in the environment namespace, used to authenticate the BuildKit **push** of the built image. Create it before deploying.
+
+Image **pull** auth is separate: the `containerImages` recipe does not configure kubelet pull credentials, so the built image repository must be publicly readable by the cluster, or you must configure a Kubernetes image-pull secret (e.g. a `kubernetes.io/dockerconfigjson` `imagePullSecret` on the namespace's `default` ServiceAccount) before deploying `app.bicep` — otherwise the app pods fail with `ImagePullBackOff`.
+
+## Notes
+The app disables mongo-express basic auth for the sample and connects with SSL enabled. The environment can optionally allow a supplied client egress IP through the Cosmos DB firewall; otherwise public access remains disabled.
+
+The Radius resource creates database `mongo_db` in the Cosmos DB account. The account name is supplied as an `app.bicep` parameter so verification can use the same globally unique value in Radius and Azure.
+
+Additional deployment details:
+- The mongo-express container exposes web port 8081.
+- The image build uses the upstream mongo-express repository at tag `v1.0.2`.

--- a/samples/mongo-express-mongo-express/app.bicep
+++ b/samples/mongo-express-mongo-express/app.bicep
@@ -1,0 +1,84 @@
+extension radius
+
+@description('The ID of your Radius Environment. Set automatically by the rad CLI.')
+param environment string
+
+@description('The Radius resource name. The workflow passes the same globally-unique value used for the Cosmos DB account so verification can use one name for both Radius and Azure.')
+param accountName string
+
+var databaseName = 'mongo_db'
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'mongodb-azure-app-test'
+  properties: {
+    environment: environment
+  }
+}
+
+resource mongo 'Radius.Data/mongoDatabases@2025-08-01-preview' = {
+  name: accountName
+  properties: {
+    environment: environment
+    application: app.id
+    database: databaseName
+  }
+}
+
+resource mongoExpressImage 'Radius.Compute/containerImages@2025-08-01-preview' = {
+  name: 'mongo-express-image'
+  properties: {
+    environment: environment
+    application: app.id
+
+    tag: 'v1.0.2'
+    build: {
+      source: 'git::https://github.com/mongo-express/mongo-express.git//?ref=v1.0.2'
+    }
+  }
+}
+
+resource mectr 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'mectr'
+  properties: {
+    environment: environment
+    application: app.id
+    containers: {
+      mongoexpress: {
+        image: mongoExpressImage.properties.imageReference
+        ports: {
+          web: {
+            containerPort: 8081
+          }
+        }
+        env: {
+          ME_CONFIG_MONGODB_URL: {
+            valueFrom: {
+              secretKeyRef: {
+                secretName: mongo.properties.secrets.name
+                key: 'connectionString'
+              }
+            }
+          }
+
+          ME_CONFIG_MONGODB_SSL: {
+            value: 'true'
+          }
+
+          ME_CONFIG_BASICAUTH: {
+            value: 'false'
+          }
+
+          ME_CONFIG_MONGODB_ENABLE_ADMIN: {
+            value: 'true'
+          }
+        }
+      }
+    }
+
+    connections: {
+      mongo: {
+        source: mongo.id
+      }
+    }
+  }
+}

--- a/samples/mongo-express-mongo-express/bicepconfig.json
+++ b/samples/mongo-express-mongo-express/bicepconfig.json
@@ -1,0 +1,8 @@
+{
+  "experimentalFeaturesEnabled": {
+    "extensibility": true
+  },
+  "extensions": {
+    "radius": "br:biceptypes.azurecr.io/radius:latest"
+  }
+}

--- a/samples/mongo-express-mongo-express/env-azure.bicep
+++ b/samples/mongo-express-mongo-express/env-azure.bicep
@@ -1,0 +1,104 @@
+extension radius
+
+@description('Azure subscription ID the environment provisions resources into.')
+param azureSubscriptionId string
+
+@description('Azure resource group the environment provisions resources into. Must already exist.')
+param azureResourceGroup string
+
+@description('Globally-unique Cosmos DB account name (3-44 lowercase alphanumerics/hyphens). The workflow generates a unique value per run.')
+param accountName string
+
+@description('OCI ref for the Radius.Compute/containers recipe. Override to a custom build if needed; defaults to the released public recipe.')
+param containersRecipe string = 'ghcr.io/radius-project/kube-recipes/containers:latest'
+
+@description('Optional public IP allowed through the Cosmos DB account firewall — the CI runner egress IP, which the in-cluster mongo-express container also NATs through. The app-connection workflow computes it at provision time and enables public network access for it; the provisioning-only workflow leaves it empty (public access stays disabled, matching the AVM default, since that tier only checks the account exists).')
+param clientIpAddress string = ''
+
+@description('OCI registry the containerImages recipe builds and pushes the mongo-express image to (e.g. `ghcr.io/myorg`).')
+param containerImagesRegistry string
+
+@description('Kubernetes Secret (in the environment namespace) holding the push registry `username`/`password`.')
+param containerImagesRegistrySecretName string
+
+resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
+  name: 'mongodb-azure-avm'
+  properties: {
+    recipes: {
+      'Radius.Data/mongoDatabases': {
+        kind: 'bicep'
+
+        source: 'mcr.microsoft.com/bicep/avm/res/document-db/database-account:0.19.0'
+        parameters: {
+          name: accountName
+          capabilitiesToAdd: [
+            'EnableMongo'
+          ]
+          mongodbDatabases: [
+            {
+              name: '{{context.resource.properties.database}}'
+            }
+          ]
+
+          networkRestrictions: empty(clientIpAddress) ? {
+            ipRules: []
+            publicNetworkAccess: 'Disabled'
+          } : {
+            ipRules: [
+              clientIpAddress
+            ]
+            networkAclBypass: 'AzureServices'
+            publicNetworkAccess: 'Enabled'
+          }
+
+          enableTelemetry: false
+        }
+
+        outputs: {
+          endpoint: 'endpoint'
+          secrets: {
+            connectionString: 'primaryReadWriteConnectionString'
+          }
+        }
+      }
+
+      'Radius.Compute/containers': {
+        kind: 'bicep'
+        source: containersRecipe
+      }
+
+      'Radius.Security/secrets': {
+        kind: 'bicep'
+        source: 'ghcr.io/radius-project/kube-recipes/secrets:latest'
+      }
+
+      'Radius.Compute/containerImages': {
+        kind: 'terraform'
+        source: 'git::https://github.com/radius-project/resource-types-contrib.git//Compute/containerImages/recipes/kubernetes/terraform?ref=b9e0fad536a53349b98f94c5be961db84845e1b7'
+        parameters: {
+          registry: containerImagesRegistry
+          registrySecretName: containerImagesRegistrySecretName
+        }
+      }
+    }
+  }
+}
+
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
+  name: 'azure'
+  properties: {
+    providers: {
+      azure: {
+        subscriptionId: azureSubscriptionId
+        resourceGroupName: azureResourceGroup
+      }
+
+      kubernetes: {
+        namespace: 'default'
+      }
+    }
+    recipePacks: [
+      recipes.id
+    ]
+  }
+}

--- a/samples/radius-project-samples-demo/README.md
+++ b/samples/radius-project-samples-demo/README.md
@@ -1,0 +1,34 @@
+# Radius samples demo app + Radius.Data/redisCaches (Azure Managed Redis)
+
+This sample provisions an Azure Managed Redis (Redis Enterprise) cache through `Radius.Data/redisCaches` using an Azure Verified Module (AVM) recipe. It builds and runs the Radius samples demo app against the provisioned Redis cache.
+
+## What this sample shows
+- **Resource type:** `Radius.Data/redisCaches`
+- **Cloud backing (Azure):** Azure Managed Redis via the AVM `mcr.microsoft.com/bicep/avm/res/cache/redis-enterprise:0.5.1` module (`env-azure.bicep`).
+- **Application:** Radius samples demo app `demo-e2e` from commit `190d9c4c84278980d9fae402330bd5ead76b31a5`, built from source via `Radius.Compute/containerImages` and run via `imageReference`.
+- **Credential model:** The recipe exposes the Redis connection string under nested `outputs.secrets.url`. The app declares `connections.redis` and consumes the secret explicitly as `CONNECTION_REDIS_URL` via a `secretKeyRef` backed by `redis.properties.secrets`.
+
+## Files
+| File | Role |
+| --- | --- |
+| `app.bicep` | Developer view: the Radius application, Redis cache resource, demo app image build, and demo app container. |
+| `env-azure.bicep` | Platform-engineer view: the `recipePacks` binding the type to the AVM module plus supporting recipes, and the `environment`. |
+| `bicepconfig.json` | Radius Bicep extension configuration. |
+
+## Deploying
+Deploy `env-azure.bicep` (the environment) first, then `app.bicep`.
+
+This sample builds its container image from source with a `Radius.Compute/containerImages` recipe and pushes it to a registry you supply. When deploying `env-azure.bicep`, provide:
+- `containerImagesRegistry` — an OCI registry you can push to (e.g. `ghcr.io/your-org`).
+- `containerImagesRegistrySecretName` — the name of a Kubernetes Secret (`username`/`password`) in the environment namespace, used to authenticate the BuildKit **push** of the built image. Create it before deploying.
+
+Image **pull** auth is separate: the `containerImages` recipe does not configure kubelet pull credentials, so the built image repository must be publicly readable by the cluster, or you must configure a Kubernetes image-pull secret (e.g. a `kubernetes.io/dockerconfigjson` `imagePullSecret` on the namespace's `default` ServiceAccount) before deploying `app.bicep` — otherwise the app pods fail with `ImagePullBackOff`.
+
+## Notes
+The Redis recipe maps size `S` to the `Balanced_B0` Azure Managed Redis SKU and enables access-key authentication on the default database. The demo container listens on port 3000.
+
+The environment recipe outputs the Redis host, port, and primary connection string as the Radius resource properties. The app relies on Radius connection injection rather than manually wiring those values.
+
+Additional deployment details:
+- The app declares a `connections.redis` relationship to the cache.
+- The image build uses the Radius samples demo source pinned by commit.

--- a/samples/radius-project-samples-demo/app.bicep
+++ b/samples/radius-project-samples-demo/app.bicep
@@ -1,0 +1,66 @@
+extension radius
+@description('The ID of your Radius Environment. Set automatically by the rad CLI.')
+param environment string
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'redis-azure-app-test'
+  properties: {
+    environment: environment
+  }
+}
+
+resource redis 'Radius.Data/redisCaches@2025-08-01-preview' = {
+  name: 'redis'
+  properties: {
+    environment: environment
+    application: app.id
+
+    size: 'S'
+  }
+}
+
+resource demoImage 'Radius.Compute/containerImages@2025-08-01-preview' = {
+  name: 'redis-demo-image'
+  properties: {
+    environment: environment
+    application: app.id
+
+    tag: 'demo-e2e'
+    build: {
+      source: 'git::https://github.com/radius-project/samples.git//samples/demo?ref=190d9c4c84278980d9fae402330bd5ead76b31a5'
+    }
+  }
+}
+
+resource democtr 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'democtr'
+  properties: {
+    environment: environment
+    application: app.id
+    containers: {
+      demo: {
+        image: demoImage.properties.imageReference
+        ports: {
+          web: {
+            containerPort: 3000
+          }
+        }
+        env: {
+          CONNECTION_REDIS_URL: {
+            valueFrom: {
+              secretKeyRef: {
+                secretName: redis.properties.secrets.name
+                key: 'connectionString'
+              }
+            }
+          }
+        }
+      }
+    }
+    connections: {
+      redis: {
+        source: redis.id
+      }
+    }
+  }
+}

--- a/samples/radius-project-samples-demo/bicepconfig.json
+++ b/samples/radius-project-samples-demo/bicepconfig.json
@@ -1,0 +1,8 @@
+{
+  "experimentalFeaturesEnabled": {
+    "extensibility": true
+  },
+  "extensions": {
+    "radius": "br:biceptypes.azurecr.io/radius:latest"
+  }
+}

--- a/samples/radius-project-samples-demo/env-azure.bicep
+++ b/samples/radius-project-samples-demo/env-azure.bicep
@@ -1,0 +1,94 @@
+extension radius
+
+@description('Azure subscription ID the environment provisions resources into.')
+param azureSubscriptionId string
+
+@description('Azure resource group the environment provisions resources into. Must already exist.')
+param azureResourceGroup string
+
+@description('Globally-unique Azure Managed Redis (Redis Enterprise) cluster name (1-60 alphanumerics/hyphens, starts/ends with a letter or number). The workflow generates a unique value per run.')
+param cacheName string
+
+@description('OCI ref for the Radius.Compute/containers recipe. Override to a custom build if needed; defaults to the released public recipe.')
+param containersRecipe string = 'ghcr.io/radius-project/kube-recipes/containers:latest'
+
+@description('OCI registry the containerImages recipe builds and pushes the demo image to (e.g. `ghcr.io/myorg`).')
+param containerImagesRegistry string
+
+@description('Kubernetes Secret (in the environment namespace) holding the push registry `username`/`password`.')
+param containerImagesRegistrySecretName string
+
+resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
+  name: 'redis-azure-avm'
+  properties: {
+    recipes: {
+      'Radius.Data/redisCaches': {
+        kind: 'bicep'
+
+        source: 'mcr.microsoft.com/bicep/avm/res/cache/redis-enterprise:0.5.1'
+        parameters: {
+          name: cacheName
+
+          skuName: '{{context.resource.properties.size == "S" ? "Balanced_B0" : "Balanced_B1"}}'
+
+          highAvailability: 'Disabled'
+
+          database: {
+            name: 'default'
+            accessKeysAuthentication: 'Enabled'
+          }
+
+          publicNetworkAccess: 'Enabled'
+
+          enableTelemetry: false
+        }
+
+        outputs: {
+          host: 'hostName'
+          port: 'port'
+          secrets: {
+            connectionString: 'primaryConnectionString'
+          }
+        }
+      }
+
+      'Radius.Compute/containers': {
+        kind: 'bicep'
+        source: containersRecipe
+      }
+
+      'Radius.Security/secrets': {
+        kind: 'bicep'
+        source: 'ghcr.io/radius-project/kube-recipes/secrets:latest'
+      }
+
+      'Radius.Compute/containerImages': {
+        kind: 'terraform'
+        source: 'git::https://github.com/radius-project/resource-types-contrib.git//Compute/containerImages/recipes/kubernetes/terraform?ref=7f5375bf89305d7641ff645336841618b305daf8'
+        parameters: {
+          registry: containerImagesRegistry
+          registrySecretName: containerImagesRegistrySecretName
+        }
+      }
+    }
+  }
+}
+
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
+  name: 'azure'
+  properties: {
+    providers: {
+      azure: {
+        subscriptionId: azureSubscriptionId
+        resourceGroupName: azureResourceGroup
+      }
+
+      kubernetes: {
+        namespace: 'default'
+      }
+    }
+    recipePacks: [
+      recipes.id
+    ]
+  }
+}

--- a/samples/sosedoff-pgweb/README.md
+++ b/samples/sosedoff-pgweb/README.md
@@ -1,0 +1,32 @@
+# pgweb + Radius.Data/postgreSqlDatabases (Azure PostgreSQL)
+
+This sample provisions an Azure Database for PostgreSQL flexible server and database through `Radius.Data/postgreSqlDatabases` using an Azure Verified Module (AVM) recipe. It builds and runs pgweb as a browser UI for the provisioned PostgreSQL database.
+
+## What this sample shows
+- **Resource type:** `Radius.Data/postgreSqlDatabases`
+- **Cloud backing (Azure):** Azure Database for PostgreSQL via the AVM `mcr.microsoft.com/bicep/avm/res/db-for-postgre-sql/flexible-server:0.15.2` module (`env-azure.bicep`).
+- **Application:** pgweb `v0.17.0`, built from source via `Radius.Compute/containerImages` and run via `imageReference`.
+- **Credential model:** A developer-authored secure `password` parameter is set on the PostgreSQL resource and reused in `PGWEB_DATABASE_URL`.
+
+## Files
+| File | Role |
+| --- | --- |
+| `app.bicep` | Developer view: the Radius application, PostgreSQL database resource, pgweb image build, and pgweb container. |
+| `env-azure.bicep` | Platform-engineer view: the `recipePacks` binding the type to the AVM module plus supporting recipes, and the `environment`. |
+| `bicepconfig.json` | Radius Bicep extension configuration. |
+
+## Deploying
+Deploy `env-azure.bicep` (the environment) first, then `app.bicep`.
+
+This sample builds its container image from source with a `Radius.Compute/containerImages` recipe and pushes it to a registry you supply. When deploying `env-azure.bicep`, provide:
+- `containerImagesRegistry` — an OCI registry you can push to (e.g. `ghcr.io/your-org`).
+- `containerImagesRegistrySecretName` — the name of a Kubernetes Secret (`username`/`password`) in the environment namespace, used to authenticate the BuildKit **push** of the built image. Create it before deploying.
+
+Image **pull** auth is separate: the `containerImages` recipe does not configure kubelet pull credentials, so the built image repository must be publicly readable by the cluster, or you must configure a Kubernetes image-pull secret (e.g. a `kubernetes.io/dockerconfigjson` `imagePullSecret` on the namespace's `default` ServiceAccount) before deploying `app.bicep` — otherwise the app pods fail with `ImagePullBackOff`.
+
+Provide the database admin `password` parameter when deploying `app.bicep`.
+
+## Notes
+The pgweb container listens on port 8081 and connects with `sslmode=require` as user `radadmin` to database `appdb`. Its image build sets `BUILDKIT_CONTEXT_KEEP_GIT_DIR=1` because the pgweb Dockerfile needs the `.git` directory. The database firewall must allow the client egress IP.
+
+The PostgreSQL resource requests size `S`, which the recipe maps to the burstable `Standard_B1ms` SKU. If no client IP is provided, the recipe omits the PostgreSQL firewall rule.

--- a/samples/sosedoff-pgweb/app.bicep
+++ b/samples/sosedoff-pgweb/app.bicep
@@ -1,0 +1,71 @@
+extension radius
+
+@description('The ID of your Radius Environment. Set automatically by the rad CLI.')
+param environment string
+
+@description('Database admin password. Marked @secure(); Radius encrypts it and injects it into the recipe and the pgweb connection URL.')
+@secure()
+param password string
+
+var databaseName = 'appdb'
+
+var databaseUsername = 'radadmin'
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'postgresql-pgweb-test'
+  properties: {
+    environment: environment
+  }
+}
+
+resource postgresql 'Radius.Data/postgreSqlDatabases@2025-08-01-preview' = {
+  name: 'postgresql'
+  properties: {
+    environment: environment
+    application: app.id
+    size: 'S'
+    database: databaseName
+
+    username: databaseUsername
+    password: password
+  }
+}
+
+resource pgwebImage 'Radius.Compute/containerImages@2025-08-01-preview' = {
+  name: 'pgweb-image'
+  properties: {
+    environment: environment
+    application: app.id
+
+    tag: 'v0.17.0'
+    build: {
+      source: 'git::https://github.com/sosedoff/pgweb.git//?ref=v0.17.0'
+      args: {
+        BUILDKIT_CONTEXT_KEEP_GIT_DIR: '1'
+      }
+    }
+  }
+}
+
+resource pgwebctr 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'pgwebctr'
+  properties: {
+    environment: environment
+    application: app.id
+    containers: {
+      pgweb: {
+        image: pgwebImage.properties.imageReference
+        ports: {
+          web: {
+            containerPort: 8081
+          }
+        }
+        env: {
+          PGWEB_DATABASE_URL: {
+            value: 'postgres://${databaseUsername}:${password}@${postgresql.properties.host}:5432/${databaseName}?sslmode=require'
+          }
+        }
+      }
+    }
+  }
+}

--- a/samples/sosedoff-pgweb/bicepconfig.json
+++ b/samples/sosedoff-pgweb/bicepconfig.json
@@ -1,0 +1,8 @@
+{
+  "experimentalFeaturesEnabled": {
+    "extensibility": true
+  },
+  "extensions": {
+    "radius": "br:biceptypes.azurecr.io/radius:latest"
+  }
+}

--- a/samples/sosedoff-pgweb/env-azure.bicep
+++ b/samples/sosedoff-pgweb/env-azure.bicep
@@ -1,0 +1,117 @@
+extension radius
+
+@description('Azure subscription ID the environment provisions resources into.')
+param azureSubscriptionId string
+
+@description('Azure resource group the environment provisions resources into. Must already exist.')
+param azureResourceGroup string
+
+@description('Globally-unique PostgreSQL flexible server name (3-63 lowercase alphanumerics/hyphens). The workflow generates a unique value per run.')
+param serverName string
+
+@description('Optional public IP allowed through the flexible server firewall — the CI runner egress IP, which the in-cluster app container also NATs through. The connection-test workflow computes it at provision time; the provisioning-only workflow leaves it empty (no firewall rule is added).')
+param clientIpAddress string = ''
+
+@description('OCI registry the containerImages recipe builds and pushes the pgweb image to (e.g. `ghcr.io/myorg`).')
+param containerImagesRegistry string
+
+@description('Kubernetes Secret (in the environment namespace) holding the push registry `username`/`password`.')
+param containerImagesRegistrySecretName string
+
+@description('OCI ref for the Radius.Compute/containers recipe. Override to a custom build if needed; defaults to the released public recipe.')
+param containersRecipe string = 'ghcr.io/radius-project/kube-recipes/containers:latest'
+
+resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
+  name: 'postgresql-azure-app-avm'
+  properties: {
+    recipes: {
+      'Radius.Data/postgreSqlDatabases': {
+        kind: 'bicep'
+
+        source: 'mcr.microsoft.com/bicep/avm/res/db-for-postgre-sql/flexible-server:0.15.2'
+        parameters: {
+          name: serverName
+
+          administratorLogin: '{{context.resource.properties.username}}'
+          administratorLoginPassword: '{{context.resource.properties.password}}'
+
+          authConfig: {
+            activeDirectoryAuth: 'Enabled'
+            passwordAuth: 'Enabled'
+          }
+
+          firewallRules: empty(clientIpAddress) ? [] : [
+            {
+              name: 'e2e-runner'
+              startIpAddress: clientIpAddress
+              endIpAddress: clientIpAddress
+            }
+          ]
+
+          skuName: '{{context.resource.properties.size == "S" ? "Standard_B1ms" : "Standard_D2ds_v5"}}'
+          tier: '{{context.resource.properties.size == "S" ? "Burstable" : "GeneralPurpose"}}'
+
+          databases: [
+            {
+              name: '{{context.resource.properties.database}}'
+            }
+          ]
+          version: '16'
+
+          availabilityZone: -1
+
+          highAvailability: 'Disabled'
+          geoRedundantBackup: 'Disabled'
+          storageSizeGB: 32
+
+          publicNetworkAccess: 'Enabled'
+          enableAdvancedThreatProtection: false
+
+          enableTelemetry: false
+        }
+
+        outputs: {
+          host: 'fqdn'
+        }
+      }
+
+      'Radius.Compute/containers': {
+        kind: 'bicep'
+        source: containersRecipe
+      }
+
+      'Radius.Security/secrets': {
+        kind: 'bicep'
+        source: 'ghcr.io/radius-project/kube-recipes/secrets:latest'
+      }
+
+      'Radius.Compute/containerImages': {
+        kind: 'terraform'
+        source: 'git::https://github.com/radius-project/resource-types-contrib.git//Compute/containerImages/recipes/kubernetes/terraform'
+        parameters: {
+          registry: containerImagesRegistry
+          registrySecretName: containerImagesRegistrySecretName
+        }
+      }
+    }
+  }
+}
+
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
+  name: 'azure'
+  properties: {
+    providers: {
+      azure: {
+        subscriptionId: azureSubscriptionId
+        resourceGroupName: azureResourceGroup
+      }
+
+      kubernetes: {
+        namespace: 'default'
+      }
+    }
+    recipePacks: [
+      recipes.id
+    ]
+  }
+}

--- a/samples/sqlpad-sqlpad/README.md
+++ b/samples/sqlpad-sqlpad/README.md
@@ -1,0 +1,32 @@
+# SQLPad UI + Radius.Data/sqlServerDatabases (Azure SQL)
+
+This sample provisions an Azure SQL logical server and database through `Radius.Data/sqlServerDatabases` using an Azure Verified Module (AVM) recipe. It builds and runs SQLPad as a browser UI with a preconfigured connection to the provisioned database.
+
+## What this sample shows
+- **Resource type:** `Radius.Data/sqlServerDatabases`
+- **Cloud backing (Azure):** Azure SQL via the AVM `mcr.microsoft.com/bicep/avm/res/sql/server:0.21.4` module (`env-azure.bicep`).
+- **Application:** SQLPad `v7.5.7` from commit `ab1f0c03269f0178b9449d34505ce3462271f340`, built from source via `Radius.Compute/containerImages` and run via `imageReference`.
+- **Credential model:** A developer-authored secure `password` parameter is set on the SQL Server resource and reused in the SQLPad `azure_sql` connection.
+
+## Files
+| File | Role |
+| --- | --- |
+| `app.bicep` | Developer view: the Radius application, SQL Server database resource, SQLPad image build, and SQLPad container. |
+| `env-azure.bicep` | Platform-engineer view: the `recipePacks` binding the type to the AVM module plus supporting recipes, and the `environment`. |
+| `bicepconfig.json` | Radius Bicep extension configuration. |
+
+## Deploying
+Deploy `env-azure.bicep` (the environment) first, then `app.bicep`.
+
+This sample builds its container image from source with a `Radius.Compute/containerImages` recipe and pushes it to a registry you supply. When deploying `env-azure.bicep`, provide:
+- `containerImagesRegistry` — an OCI registry you can push to (e.g. `ghcr.io/your-org`).
+- `containerImagesRegistrySecretName` — the name of a Kubernetes Secret (`username`/`password`) in the environment namespace, used to authenticate the BuildKit **push** of the built image. Create it before deploying.
+
+Image **pull** auth is separate: the `containerImages` recipe does not configure kubelet pull credentials, so the built image repository must be publicly readable by the cluster, or you must configure a Kubernetes image-pull secret (e.g. a `kubernetes.io/dockerconfigjson` `imagePullSecret` on the namespace's `default` ServiceAccount) before deploying `app.bicep` — otherwise the app pods fail with `ImagePullBackOff`.
+
+Provide the database admin `password` parameter when deploying `app.bicep`.
+
+## Notes
+SQLPad was archived by its maintainers in August 2025; this sample pins tag `v7.5.7` and remains suitable as a sample. The container listens on port 3000, disables auth with the default admin role, and configures an `azure_sql` connection using driver `sqlserver`, encryption on, and certificate trust disabled.
+
+The SQL recipe creates database `appdb` on a Basic Azure SQL database and allows Azure services through the server firewall. The SQLPad data path is `/var/lib/sqlpad` inside the container.

--- a/samples/sqlpad-sqlpad/app.bicep
+++ b/samples/sqlpad-sqlpad/app.bicep
@@ -1,0 +1,107 @@
+extension radius
+
+@description('The ID of your Radius Environment. Set automatically by the rad CLI.')
+param environment string
+
+@description('Database admin password. Marked @secure(); Radius encrypts it and injects it into the recipe and the SQLPad connection.')
+@secure()
+param password string
+
+var databaseName = 'appdb'
+
+var databaseUsername = 'radadmin'
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'sqlpad-azure-app-test'
+  properties: {
+    environment: environment
+  }
+}
+
+resource sqlserver 'Radius.Data/sqlServerDatabases@2025-08-01-preview' = {
+  name: 'sqlserver'
+  properties: {
+    environment: environment
+    application: app.id
+    database: databaseName
+
+    username: databaseUsername
+    password: password
+  }
+}
+
+resource sqlpadImage 'Radius.Compute/containerImages@2025-08-01-preview' = {
+  name: 'sqlpad-image'
+  properties: {
+    environment: environment
+    application: app.id
+    tag: 'v7.5.7'
+    build: {
+      source: 'git::https://github.com/sqlpad/sqlpad.git//?ref=ab1f0c03269f0178b9449d34505ce3462271f340'
+    }
+  }
+}
+
+resource sqlpadctr 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'sqlpadctr'
+  properties: {
+    environment: environment
+    application: app.id
+    containers: {
+      sqlpad: {
+        image: sqlpadImage.properties.imageReference
+        ports: {
+          web: {
+            containerPort: 3000
+          }
+        }
+        env: {
+          SQLPAD_PORT: {
+            value: '3000'
+          }
+          SQLPAD_DB_PATH: {
+            value: '/var/lib/sqlpad'
+          }
+          SQLPAD_AUTH_DISABLED: {
+            value: 'true'
+          }
+          SQLPAD_AUTH_DISABLED_DEFAULT_ROLE: {
+            value: 'admin'
+          }
+          SQLPAD_CONNECTIONS__azure_sql__name: {
+            value: 'Azure SQL'
+          }
+          SQLPAD_CONNECTIONS__azure_sql__driver: {
+            value: 'sqlserver'
+          }
+          SQLPAD_CONNECTIONS__azure_sql__host: {
+            value: sqlserver.properties.host
+          }
+          SQLPAD_CONNECTIONS__azure_sql__port: {
+            value: '1433'
+          }
+          SQLPAD_CONNECTIONS__azure_sql__database: {
+            value: databaseName
+          }
+          SQLPAD_CONNECTIONS__azure_sql__username: {
+            value: databaseUsername
+          }
+          SQLPAD_CONNECTIONS__azure_sql__password: {
+            value: password
+          }
+          SQLPAD_CONNECTIONS__azure_sql__sqlserverEncrypt: {
+            value: 'true'
+          }
+          SQLPAD_CONNECTIONS__azure_sql__trustServerCertificate: {
+            value: 'false'
+          }
+        }
+      }
+    }
+    connections: {
+      sqlserver: {
+        source: sqlserver.id
+      }
+    }
+  }
+}

--- a/samples/sqlpad-sqlpad/bicepconfig.json
+++ b/samples/sqlpad-sqlpad/bicepconfig.json
@@ -1,0 +1,8 @@
+{
+  "experimentalFeaturesEnabled": {
+    "extensibility": true
+  },
+  "extensions": {
+    "radius": "br:biceptypes.azurecr.io/radius:latest"
+  }
+}

--- a/samples/sqlpad-sqlpad/env-azure.bicep
+++ b/samples/sqlpad-sqlpad/env-azure.bicep
@@ -1,0 +1,94 @@
+extension radius
+
+@description('Azure subscription ID the environment provisions resources into.')
+param azureSubscriptionId string
+
+@description('Azure resource group the environment provisions resources into. Must already exist.')
+param azureResourceGroup string
+
+@description('Globally-unique Azure SQL logical server name (1-63 lowercase alphanumerics/hyphens). The workflow generates a unique value per run.')
+param serverName string
+
+@description('OCI ref for the Radius.Compute/containers recipe. Override to a custom build if needed; defaults to the released public recipe.')
+param containersRecipe string = 'ghcr.io/radius-project/kube-recipes/containers:latest'
+
+@description('OCI registry the containerImages recipe builds and pushes the SQLPad image to (e.g. `ghcr.io/myorg`).')
+param containerImagesRegistry string
+
+@description('Kubernetes Secret (in the environment namespace) holding the push registry `username`/`password`.')
+param containerImagesRegistrySecretName string
+
+resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
+  name: 'sqlserver-azure-avm'
+  properties: {
+    recipes: {
+      'Radius.Data/sqlServerDatabases': {
+        kind: 'bicep'
+
+        source: 'mcr.microsoft.com/bicep/avm/res/sql/server:0.21.4'
+        parameters: {
+          name: serverName
+          administratorLogin: '{{context.resource.properties.username}}'
+          administratorLoginPassword: '{{context.resource.properties.password}}'
+          publicNetworkAccess: 'Enabled'
+          firewallRules: [
+            {
+              name: 'AllowAllWindowsAzureIps'
+              startIpAddress: '0.0.0.0'
+              endIpAddress: '0.0.0.0'
+            }
+          ]
+          databases: [
+            {
+              name: '{{context.resource.properties.database}}'
+              availabilityZone: -1
+              sku: {
+                name: 'Basic'
+                tier: 'Basic'
+              }
+              maxSizeBytes: 2147483648
+              zoneRedundant: false
+            }
+          ]
+          enableTelemetry: false
+        }
+
+        outputs: {
+          host: 'fullyQualifiedDomainName'
+        }
+      }
+
+      'Radius.Compute/containers': {
+        kind: 'bicep'
+        source: containersRecipe
+      }
+
+      'Radius.Compute/containerImages': {
+        kind: 'terraform'
+        source: 'git::https://github.com/radius-project/resource-types-contrib.git//Compute/containerImages/recipes/kubernetes/terraform?ref=b9e0fad536a53349b98f94c5be961db84845e1b7'
+        parameters: {
+          registry: containerImagesRegistry
+          registrySecretName: containerImagesRegistrySecretName
+        }
+      }
+    }
+  }
+}
+
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
+  name: 'azure'
+  properties: {
+    providers: {
+      azure: {
+        subscriptionId: azureSubscriptionId
+        resourceGroupName: azureResourceGroup
+      }
+      kubernetes: {
+        namespace: 'default'
+      }
+    }
+    recipePacks: [
+      recipes.id
+    ]
+  }
+}

--- a/samples/warpstreamlabs-bento/README.md
+++ b/samples/warpstreamlabs-bento/README.md
@@ -1,0 +1,34 @@
+# Bento pipeline + Radius.Messaging/rabbitMQ (Azure Service Bus)
+
+This sample provisions an Azure Service Bus namespace and queue through `Radius.Messaging/rabbitMQ` using an Azure Verified Module (AVM) recipe. It builds and runs Bento as a producer/consumer streaming pipeline over the provisioned queue.
+
+## What this sample shows
+- **Resource type:** `Radius.Messaging/rabbitMQ`
+- **Cloud backing (Azure):** Azure Service Bus via the AVM `mcr.microsoft.com/bicep/avm/res/service-bus/namespace:0.16.2` module (`env-azure.bicep`).
+- **Application:** WarpStream Bento `v1.18.1`, built from source via `Radius.Compute/containerImages` with `resources/docker/Dockerfile` and run via `imageReference`.
+- **Credential model:** The recipe exposes the queue connection string under nested `outputs.secrets.connectionString`. Both containers read the non-secret `queue.properties.host` directly and consume the connection string as `RABBITMQ_CONNECTIONSTRING` via a `secretKeyRef` backed by `queue.properties.secrets`, deriving the Service Bus AMQP endpoint and SAS key from them.
+
+## Files
+| File | Role |
+| --- | --- |
+| `app.bicep` | Developer view: the Radius application, Bento image build, queue resource, and producer/consumer containers. |
+| `env-azure.bicep` | Platform-engineer view: the `recipePacks` binding the type to the AVM module plus supporting recipes, and the `environment`. |
+| `bicepconfig.json` | Radius Bicep extension configuration. |
+
+## Deploying
+Deploy `env-azure.bicep` (the environment) first, then `app.bicep`.
+
+This sample builds its container image from source with a `Radius.Compute/containerImages` recipe and pushes it to a registry you supply. When deploying `env-azure.bicep`, provide:
+- `containerImagesRegistry` — an OCI registry you can push to (e.g. `ghcr.io/your-org`).
+- `containerImagesRegistrySecretName` — the name of a Kubernetes Secret (`username`/`password`) in the environment namespace, used to authenticate the BuildKit **push** of the built image. Create it before deploying.
+
+Image **pull** auth is separate: the `containerImages` recipe does not configure kubelet pull credentials, so the built image repository must be publicly readable by the cluster, or you must configure a Kubernetes image-pull secret (e.g. a `kubernetes.io/dockerconfigjson` `imagePullSecret` on the namespace's `default` ServiceAccount) before deploying `app.bicep` — otherwise the app pods fail with `ImagePullBackOff`.
+
+## Notes
+The `producer` container generates messages every five seconds and publishes them to the `jobs` queue over AMQP 1.0. The `consumer` container continuously reads the same queue with lock renewal enabled and logs messages to stdout.
+
+Both containers run the same built Bento image and generate their pipeline YAML files at startup. The Service Bus recipe creates the `jobs` queue from the Radius resource's `queue` property.
+
+Additional deployment details:
+- The app declares a `connections.rabbitmq` relationship to the queue.
+- The Service Bus namespace uses the Standard SKU with local auth enabled.

--- a/samples/warpstreamlabs-bento/app.bicep
+++ b/samples/warpstreamlabs-bento/app.bicep
@@ -1,0 +1,128 @@
+extension radius
+
+@description('The ID of your Radius Environment. Set automatically by the rad CLI.')
+param environment string
+
+resource app 'Radius.Core/applications@2025-08-01-preview' = {
+  name: 'rabbitmq-azure-app-test'
+  properties: {
+    environment: environment
+  }
+}
+
+resource bentoImage 'Radius.Compute/containerImages@2025-08-01-preview' = {
+  name: 'bento-image'
+  properties: {
+    environment: environment
+    application: app.id
+    tag: 'v1.18.1'
+    build: {
+      source: 'git::https://github.com/warpstreamlabs/bento.git//?ref=v1.18.1'
+      dockerfile: 'resources/docker/Dockerfile'
+    }
+  }
+}
+
+resource queue 'Radius.Messaging/rabbitMQ@2025-08-01-preview' = {
+  name: 'rabbitmq'
+  properties: {
+    environment: environment
+    application: app.id
+    queue: 'jobs'
+  }
+}
+
+resource bentoctr 'Radius.Compute/containers@2025-08-01-preview' = {
+  name: 'bentoctr'
+  properties: {
+    environment: environment
+    application: app.id
+    containers: {
+      producer: {
+        image: bentoImage.properties.imageReference
+        env: {
+          RABBITMQ_HOST: {
+            value: queue.properties.host
+          }
+          RABBITMQ_CONNECTIONSTRING: {
+            valueFrom: {
+              secretKeyRef: {
+                secretName: queue.properties.secrets.name
+                key: 'connectionString'
+              }
+            }
+          }
+        }
+        command: [
+          '/bin/sh'
+          '-c'
+          '''
+set -eu
+NS="$RABBITMQ_HOST"
+KEY=$(printf '%s' "$RABBITMQ_CONNECTIONSTRING" | sed -n 's/.*SharedAccessKey=//p')
+cat > /tmp/producer.yaml <<EOF
+input:
+  generate:
+    count: 0
+    interval: 5s
+    mapping: 'root = {"message":"radius-bento","timestamp":now()}'
+output:
+  amqp_1:
+    url: amqps://$NS.servicebus.windows.net
+    target_address: jobs
+    sasl:
+      mechanism: plain
+      user: RootManageSharedAccessKey
+      password: "$KEY"
+EOF
+exec /bento -c /tmp/producer.yaml
+'''
+        ]
+      }
+      consumer: {
+        image: bentoImage.properties.imageReference
+        env: {
+          RABBITMQ_HOST: {
+            value: queue.properties.host
+          }
+          RABBITMQ_CONNECTIONSTRING: {
+            valueFrom: {
+              secretKeyRef: {
+                secretName: queue.properties.secrets.name
+                key: 'connectionString'
+              }
+            }
+          }
+        }
+        command: [
+          '/bin/sh'
+          '-c'
+          '''
+set -eu
+NS="$RABBITMQ_HOST"
+KEY=$(printf '%s' "$RABBITMQ_CONNECTIONSTRING" | sed -n 's/.*SharedAccessKey=//p')
+cat > /tmp/consumer.yaml <<EOF
+input:
+  amqp_1:
+    url: amqps://$NS.servicebus.windows.net
+    source_address: jobs
+    azure_renew_lock: true
+    sasl:
+      mechanism: plain
+      user: RootManageSharedAccessKey
+      password: "$KEY"
+output:
+  stdout: {}
+EOF
+exec /bento -c /tmp/consumer.yaml
+'''
+        ]
+      }
+    }
+    connections: {
+      rabbitmq: {
+        source: queue.id
+      }
+    }
+  }
+}

--- a/samples/warpstreamlabs-bento/bicepconfig.json
+++ b/samples/warpstreamlabs-bento/bicepconfig.json
@@ -1,0 +1,8 @@
+{
+  "experimentalFeaturesEnabled": {
+    "extensibility": true
+  },
+  "extensions": {
+    "radius": "br:biceptypes.azurecr.io/radius:latest"
+  }
+}

--- a/samples/warpstreamlabs-bento/env-azure.bicep
+++ b/samples/warpstreamlabs-bento/env-azure.bicep
@@ -1,0 +1,93 @@
+extension radius
+
+@description('Azure subscription ID the environment provisions resources into.')
+param azureSubscriptionId string
+
+@description('Azure resource group the environment provisions resources into. Must already exist.')
+param azureResourceGroup string
+
+@description('Globally-unique Azure Service Bus namespace name (6-50 alphanumerics/hyphens, starts with a letter). The workflow generates a unique value per run.')
+param namespaceName string
+
+@description('OCI ref for the Radius.Compute/containers recipe. Override to a custom build if needed; defaults to the released public recipe.')
+param containersRecipe string = 'ghcr.io/radius-project/kube-recipes/containers:latest'
+
+@description('OCI registry the containerImages recipe builds and pushes the Bento image to (e.g. `ghcr.io/myorg`).')
+param containerImagesRegistry string
+
+@description('Kubernetes Secret (in the environment namespace) holding the push registry `username`/`password`.')
+param containerImagesRegistrySecretName string
+
+resource recipes 'Radius.Core/recipePacks@2025-08-01-preview' = {
+  name: 'rabbitmq-azure-avm'
+  properties: {
+    recipes: {
+      'Radius.Messaging/rabbitMQ': {
+        kind: 'bicep'
+
+        source: 'mcr.microsoft.com/bicep/avm/res/service-bus/namespace:0.16.2'
+        parameters: {
+          name: namespaceName
+          skuObject: {
+            name: 'Standard'
+          }
+
+          zoneRedundant: false
+
+          disableLocalAuth: false
+          queues: [
+            {
+              name: '{{context.resource.properties.queue}}'
+            }
+          ]
+
+          enableTelemetry: false
+        }
+
+        outputs: {
+          host: 'name'
+          secrets: {
+            connectionString: 'primaryConnectionString'
+          }
+        }
+      }
+      'Radius.Compute/containers': {
+        kind: 'bicep'
+        source: containersRecipe
+      }
+
+      'Radius.Security/secrets': {
+        kind: 'bicep'
+        source: 'ghcr.io/radius-project/kube-recipes/secrets:latest'
+      }
+
+      'Radius.Compute/containerImages': {
+        kind: 'terraform'
+        source: 'git::https://github.com/radius-project/resource-types-contrib.git//Compute/containerImages/recipes/kubernetes/terraform?ref=b9e0fad536a53349b98f94c5be961db84845e1b7'
+        parameters: {
+          registry: containerImagesRegistry
+          registrySecretName: containerImagesRegistrySecretName
+        }
+      }
+    }
+  }
+}
+
+resource env 'Radius.Core/environments@2025-08-01-preview' = {
+  name: 'azure'
+  properties: {
+    providers: {
+      azure: {
+        subscriptionId: azureSubscriptionId
+        resourceGroupName: azureResourceGroup
+      }
+
+      kubernetes: {
+        namespace: 'default'
+      }
+    }
+    recipePacks: [
+      recipes.id
+    ]
+  }
+}


### PR DESCRIPTION
## Description

Adds 10 self-contained samples under `samples/<app>/`, each demonstrating a Radius resource type backed by an Azure recipe. Every sample includes a developer-facing `app.bicep`, a platform-facing `env-azure.bicep`, `bicepconfig.json`, and focused usage documentation.

## Samples

| Sample | Resource type | Application |
| --- | --- | --- |
| `kafka-ui` | `Radius.Messaging/kafka` | [Kafbat Kafka UI](https://github.com/kafbat/kafka-ui) |
| `berriai-litellm` | `Radius.AI/models` | [LiteLLM proxy](https://github.com/BerriAI/litellm) |
| `mongo-express-mongo-express` | `Radius.Data/mongoDatabases` | [mongo-express](https://github.com/mongo-express/mongo-express) |
| `dockersamples-todo-list-app` | `Radius.Data/mySqlDatabases` | [Docker todo-list app](https://github.com/docker/getting-started-todo-app) |
| `sosedoff-pgweb` | `Radius.Data/postgreSqlDatabases` | [pgweb](https://github.com/sosedoff/pgweb) |
| `warpstreamlabs-bento` | `Radius.Messaging/rabbitMQ` | [Bento streaming pipeline](https://github.com/warpstreamlabs/bento) |
| `radius-project-samples-demo` | `Radius.Data/redisCaches` | [Radius demo app](https://github.com/radius-project/samples/tree/edge/samples/demo) |
| `sqlpad-sqlpad` | `Radius.Data/sqlServerDatabases` | [SQLPad](https://github.com/sqlpad/sqlpad) |
| `azure-search-api` | `Radius.AI/search` | [Go Azure AI Search API](https://github.com/radius-project/samples/tree/edge/samples/azure-search-api) |
| `drakkan-sftpgo` | `Radius.Storage/objectStorage` | [SFTPGo](https://github.com/drakkan/sftpgo) |

## Highlights

- Nine samples build their workload from source through `Radius.Compute/containerImages` and run the resulting `imageReference`.
- `kafka-ui` uses the pinned official image because maintained Kafka UIs require a prebuilt JAR rather than offering a self-contained source-build Dockerfile.
- `azure-search-api` adds a standard-library Go service with health, indexing, and query endpoints plus unit tests.
- `sqlpad-sqlpad` replaces a one-shot migration probe with a long-running Azure SQL UI. SQLPad is pinned to v7.5.7; upstream archived the project in August 2025.
- Bento runs a continuous producer/consumer pipeline instead of a one-shot verification script.
- Sensitive recipe outputs retain the nested `outputs.secrets { ... }` contract and are consumed through `properties.secrets` plus `secretKeyRef`.
- BuildKit push credentials and Kubernetes image-pull credentials are documented separately. Users must provide a pushable registry and ensure built images are publicly readable or configure an image-pull secret.

## Validation

- Azure Search API: `go test ./...`, `go vet ./...`, and formatting checks pass.
- SQLPad and other samples without recipe-produced secrets compile against the current published Radius extension.
- Samples using nested recipe secrets currently fail Bicep validation against `br:biceptypes.azurecr.io/radius:latest` because that artifact still exposes the older flat secret schema (`BCP053`/`BCP036`). The samples intentionally preserve the nested contract and require the published Radius extension to be regenerated with that schema.