### PR TITLE
Bundle Bootstrap via Vite instead of jsDelivr CDN

### DIFF
--- a/samples/demo/Dockerfile
+++ b/samples/demo/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:22-bookworm AS build
 WORKDIR /usr/src/app
 
+ARG NPM_CONFIG_REGISTRY=https://registry.npmjs.org/
+
 COPY package.json package-lock.json ./
 COPY client/package.json client/package-lock.json ./client/
 RUN npm ci && npm cache clean --force

--- a/samples/demo/README.md
+++ b/samples/demo/README.md
@@ -3,3 +3,14 @@
 This application is used to demonstrate Radius basics as part of our 'first application' tutorial.
 
 Visit https://radapp.io to try it out.
+
+## Build the container image with a configured npm registry
+
+To use the npm registry configured on the host, pass it to the container build:
+
+```sh
+docker build \
+  --build-arg NPM_CONFIG_REGISTRY="$(npm config get registry)" \
+  --tag radius-demo:local \
+  samples/demo
+```

--- a/samples/demo/client/index.html
+++ b/samples/demo/client/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
@@ -27,5 +26,4 @@
     <div id="root"></div>
     <script type="module" src="/src/index.tsx"></script>
   </body>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3" crossorigin="anonymous"></script>
 </html>

--- a/samples/demo/client/package-lock.json
+++ b/samples/demo/client/package-lock.json
@@ -16,6 +16,7 @@
         "@types/react": "^19.2.16",
         "@types/react-dom": "^19.2.3",
         "@types/react-router-dom": "^5.3.3",
+        "bootstrap": "^5.3.8",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-router": "^8.3.0",
@@ -200,6 +201,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha1-a3kDLnYKCJnNQgRxC+7elyo6GF8=",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -774,6 +786,25 @@
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/bootstrap": {
+      "version": "5.3.8",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/bootstrap/-/bootstrap-5.3.8.tgz",
+      "integrity": "sha1-ZAGhAFeiJ1LSH04ZBVUImAZWru0=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/braces": {

--- a/samples/demo/client/package.json
+++ b/samples/demo/client/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",
     "@types/react-router-dom": "^5.3.3",
+    "bootstrap": "^5.3.8",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-router": "^8.3.0",

--- a/samples/demo/client/public/index.html
+++ b/samples/demo/client/public/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
@@ -26,5 +25,4 @@
     </nav>
     <div id="root"></div>
   </body>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-OERcA2EqjJCMA+/3y+gxIOqMEjwtxJY7qPCqsdltbNJuaOe923+mo//f6V8Qbsw3" crossorigin="anonymous"></script>
 </html>

--- a/samples/demo/client/src/index.tsx
+++ b/samples/demo/client/src/index.tsx
@@ -4,8 +4,9 @@ import {
   createBrowserRouter,
   RouterProvider,
 } from "react-router-dom";
+import 'bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap';
 import "./index.css";
-import './index.css';
 import Root from './Root';
 import ErrorPage from './ErrorPage';
 import reportWebVitals from './reportWebVitals';

--- a/samples/demo/package-lock.json
+++ b/samples/demo/package-lock.json
@@ -16,7 +16,6 @@
         "@types/pg": "^8.20.0",
         "@types/redis": "^4.0.11",
         "@types/uuid": "^11.0.0",
-        "bootstrap": "^5.3.8",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "mongodb": "^7.2.0",
@@ -1592,17 +1591,6 @@
         "node": "^18.19.0 || >=20.6.0"
       }
     },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -2186,25 +2174,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/bootstrap": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
-      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/twbs"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/bootstrap"
-        }
-      ],
-      "license": "MIT",
-      "peerDependencies": {
-        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/brace-expansion": {

--- a/samples/demo/package.json
+++ b/samples/demo/package.json
@@ -30,7 +30,6 @@
     "@types/pg": "^8.20.0",
     "@types/redis": "^4.0.11",
     "@types/uuid": "^11.0.0",
-    "bootstrap": "^5.3.8",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "mongodb": "^7.2.0",


### PR DESCRIPTION
## Summary

Bundle Bootstrap through the Vite build instead of loading it from the jsDelivr CDN, so the Todo list demo renders with correct styling even when an organization's Microsoft Defender policy blocks npm-backed CDN URLs.

## Reason for change

`client/index.html` referenced Bootstrap CSS and JS from `cdn.jsdelivr.net`. In environments where Microsoft Defender blocks npm-backed jsDelivr URLs, the browser fails to load these resources (`ERR_SOCKET_NOT_CONNECTED`), so the demo loads without Bootstrap styling. Installing Bootstrap as a client dependency and importing it into the Vite bundle removes the runtime dependency on an external CDN.

Fixes #2638

## How to test

1. Build the demo image (pass an approved npm registry if the default is blocked):

   `docker build --build-arg NPM_CONFIG_REGISTRY="$(npm config get registry)" -t ghcr.io/radius-project/samples/demo:test ./samples/demo`

2. Load it into a local Kind cluster and deploy:

   `kind load docker-image ghcr.io/radius-project/samples/demo:test --name <cluster>`

3. Edit the container image in the app.bicep to point to :test rather than :latest

4. Deploy

   `rad deploy ./samples/demo/app.bicep --application demo --environment default`

5. Port-forward the demo container and open it in a browser.
6. Confirm the UI renders with Bootstrap styling and the served HTML contains no `cdn.jsdelivr.net` references.

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| samples/demo/client/src/index.tsx | Import Bootstrap CSS and JS from the bundle; remove duplicate `index.css` import |
| samples/demo/client/index.html | Remove jsDelivr Bootstrap CSS and JS references |
| samples/demo/client/public/index.html | Remove jsDelivr Bootstrap CSS and JS references |
| samples/demo/client/package.json | Add `bootstrap` as a client dependency |
| samples/demo/client/package-lock.json | Lockfile entry for `bootstrap` |
| samples/demo/package.json | Remove unused server-side `bootstrap` dependency |
| samples/demo/package-lock.json | Remove server-side `bootstrap` lockfile entry |
| samples/demo/Dockerfile | Add `NPM_CONFIG_REGISTRY` build arg so the image can build through an approved npm registry proxy |