### PR TITLE
Modernize demo sample to Radius.* resource types and add Redis/Postgr…

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -261,8 +261,9 @@ jobs:
 
           if [[ "${{ matrix.previewFlag }}" == "true" ]]; then
             # 'rad install kubernetes --preview' already created the default resource group and
-            # the Radius.Core/environments/default environment with the default recipe pack.
-            rad workspace create kubernetes default --group default --preview
+            # the Radius.Core/environments/default environment with the default recipe pack;
+            # bind that environment to the workspace with -e so rad deploy can resolve it.
+            rad workspace create kubernetes default --group default --preview -e default
           else
             # 'rad install kubernetes' already created the default resource group and the
             # Applications.Core/environments/default environment; bind both to the workspace with

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -209,7 +209,11 @@ jobs:
       - name: Initialize default environment
         if: steps.gen-id.outputs.RUN_TEST == 'true'
         run: |
-          rad install kubernetes --set rp.publicEndpointOverride=localhost
+          if [[ "${{ matrix.previewFlag }}" == "true" ]]; then
+            rad install kubernetes --set rp.publicEndpointOverride=localhost --preview
+          else
+            rad install kubernetes --set rp.publicEndpointOverride=localhost
+          fi
 
           echo "*** Verify manifests are registered ***"
           rm -f registermanifest_logs.txt
@@ -255,15 +259,20 @@ jobs:
             exit 1
           fi
 
-          rad group create default
-          rad workspace create kubernetes default --group default
-          rad group switch default
-          rad env create default
-          rad env switch default
-          rad recipe register default -e default -w default --template-kind bicep --template-path ghcr.io/radius-project/recipes/local-dev/rediscaches:${{ steps.gen-radius-version.outputs.RADIUS_VERSION }} --resource-type Applications.Datastores/redisCaches
-          rad recipe register default -e default -w default --template-kind bicep --template-path ghcr.io/radius-project/recipes/local-dev/mongodatabases:${{ steps.gen-radius-version.outputs.RADIUS_VERSION }} --resource-type Applications.Datastores/mongoDatabases
-          rad recipe register default -e default -w default --template-kind bicep --template-path ghcr.io/radius-project/recipes/local-dev/sqldatabases:${{ steps.gen-radius-version.outputs.RADIUS_VERSION }} --resource-type Applications.Datastores/sqlDatabases
-          rad recipe register default -e default -w default --template-kind bicep --template-path ghcr.io/radius-project/recipes/local-dev/rabbitmqqueues:${{ steps.gen-radius-version.outputs.RADIUS_VERSION }} --resource-type Applications.Messaging/rabbitMQQueues
+          if [[ "${{ matrix.previewFlag }}" == "true" ]]; then
+            # 'rad install kubernetes --preview' already created the default resource group and
+            # the Radius.Core/environments/default environment with the default recipe pack.
+            rad workspace create kubernetes default --group default --preview
+          else
+            # 'rad install kubernetes' already created the default resource group and the
+            # Applications.Core/environments/default environment; bind both to the workspace with
+            # -e so no group/env switch is needed, then register the datastore recipes.
+            rad workspace create kubernetes default --group default -e default
+            rad recipe register default -e default -w default --template-kind bicep --template-path ghcr.io/radius-project/recipes/local-dev/rediscaches:${{ steps.gen-radius-version.outputs.RADIUS_VERSION }} --resource-type Applications.Datastores/redisCaches
+            rad recipe register default -e default -w default --template-kind bicep --template-path ghcr.io/radius-project/recipes/local-dev/mongodatabases:${{ steps.gen-radius-version.outputs.RADIUS_VERSION }} --resource-type Applications.Datastores/mongoDatabases
+            rad recipe register default -e default -w default --template-kind bicep --template-path ghcr.io/radius-project/recipes/local-dev/sqldatabases:${{ steps.gen-radius-version.outputs.RADIUS_VERSION }} --resource-type Applications.Datastores/sqlDatabases
+            rad recipe register default -e default -w default --template-kind bicep --template-path ghcr.io/radius-project/recipes/local-dev/rabbitmqqueues:${{ steps.gen-radius-version.outputs.RADIUS_VERSION }} --resource-type Applications.Messaging/rabbitMQQueues
+          fi
 
       # Deploy application and run tests
       # Retry the deployment step in case of transient failures

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,14 +51,16 @@ jobs:
           - name: demo
             os: ubuntu-24.04
             runOnPullRequest: true
-            app: demo
+            app: demo-default
             env: default
             path: ./samples/demo/app.bicep
-            deployArgs: --application demo -p image=sampleregistry:5000/samples/demo
-            exposeArgs: --application demo
+            deployArgs: -p image=sampleregistry:5000/samples/demo
+            exposeArgs: --application demo-default
+            # Use the preview (Radius.*) resource types for expose/delete.
+            previewFlag: true
             uiTestFile: tests/demo/demo.app.spec.ts
             port: 3000
-            container: demo
+            container: demo-default
             enableDapr: false
             images: samples/demo
             directories: samples/demo/
@@ -280,7 +282,14 @@ jobs:
         id: run-playwright-test
         run: |
           if [[ "${{ matrix.container }}" != "" ]]; then
-            rad resource expose Applications.Core/containers ${{ matrix.container }} ${{ matrix.exposeArgs }} --port ${{ matrix.port }} &
+            if [[ "${{ matrix.previewFlag }}" == "true" ]]; then
+              containerType="Radius.Compute/containers"
+              previewArg="--preview"
+            else
+              containerType="Applications.Core/containers"
+              previewArg=""
+            fi
+            rad resource expose "$containerType" ${{ matrix.container }} ${{ matrix.exposeArgs }} --port ${{ matrix.port }} $previewArg &
             export ENDPOINT="http://localhost:3000/"
           else
             endpoint="$(rad app status -a ${{ matrix.app }} | sed 's/ /\n/g' | grep http)"
@@ -350,5 +359,9 @@ jobs:
         if: steps.gen-id.outputs.RUN_TEST == 'true' && steps.deploy-app.outcome == 'success'
         run: |
           if command -v rad &> /dev/null; then
-            rad app delete ${{ matrix.app }} -y
+            previewArg=""
+            if [[ "${{ matrix.previewFlag }}" == "true" ]]; then
+              previewArg="--preview"
+            fi
+            rad app delete ${{ matrix.app }} -y $previewArg
           fi

--- a/bicepconfig.json
+++ b/bicepconfig.json
@@ -1,9 +1,5 @@
 {
-    "experimentalFeaturesEnabled": {
-        "extensibility": true
-    },
     "extensions": {
-        "radius": "br:biceptypes.azurecr.io/radius:latest",
-        "aws": "br:biceptypes.azurecr.io/aws:latest"
+        "radius": "br:biceptypes.azurecr.io/radius:latest"
     }
 }

--- a/playwright/tests/demo/demo.app.spec.ts
+++ b/playwright/tests/demo/demo.app.spec.ts
@@ -38,25 +38,6 @@ test("To-Do App Basic UI Checks", async ({ page }) => {
 
   // Go back to Main Page
   await page.getByRole("link", { name: "Radius Demo" }).click();
-
-  await page.getByRole("button", { name: "📄 Environment variables" }).click();
-
-  // Make sure important environment variables are visible
-  await expect(
-    page
-      .getByRole("cell", { name: "CONNECTION_REDIS_CONNECTIONSTRING" })
-      .getByText("CONNECTION_REDIS_CONNECTIONSTRING")
-  ).toBeVisible();
-  await expect(
-    page
-      .getByRole("cell", { name: "CONNECTION_REDIS_HOST" })
-      .getByText("CONNECTION_REDIS_HOST")
-  ).toBeVisible();
-  await expect(
-    page
-      .getByRole("cell", { name: "CONNECTION_REDIS_PORT" })
-      .getByText("CONNECTION_REDIS_PORT")
-  ).toBeVisible();
 });
 
 test("Add an item and check basic functionality", async ({ page }) => {

--- a/samples/aws-sqs/bicepconfig.json
+++ b/samples/aws-sqs/bicepconfig.json
@@ -1,0 +1,6 @@
+{
+  "extensions": {
+    "radius": "br:biceptypes.azurecr.io/radius:latest",
+    "aws": "br:biceptypes.azurecr.io/aws:latest"
+  }
+}

--- a/samples/aws/bicepconfig.json
+++ b/samples/aws/bicepconfig.json
@@ -1,0 +1,6 @@
+{
+  "extensions": {
+    "radius": "br:biceptypes.azurecr.io/radius:latest",
+    "aws": "br:biceptypes.azurecr.io/aws:latest"
+  }
+}

--- a/samples/demo/app-postgresql.bicep
+++ b/samples/demo/app-postgresql.bicep
@@ -3,6 +3,10 @@ extension radius
 @description('The Radius Environment ID. Injected automatically by the rad CLI.')
 param environment string
 
+@description('The administrator password for the PostgreSQL database. Pass via the CLI, e.g. -p password=$(openssl rand -hex 16).')
+@secure()
+param password string
+
 // Environment name derived from the Environment ID, used to keep resource names
 // unique per environment (e.g. dev/test/prod) within the same resource group.
 var environmentName = last(split(environment, '/'))
@@ -29,5 +33,22 @@ resource demoContainer 'Radius.Compute/containers@2025-08-01-preview' = {
         }
       }
     }
+    connections: {
+      postgresql: {
+        source: postgresql.id
+      }
+    }
+  }
+}
+
+resource postgresql 'Radius.Data/postgreSqlDatabases@2025-08-01-preview' = {
+  name: 'postgresql-${environmentName}'
+  properties: {
+    environment: environment
+    application: demoApp.id
+    size: 'S'
+    database: 'appdb'
+    username: 'myadmin'
+    password: password
   }
 }

--- a/samples/demo/app-redis.bicep
+++ b/samples/demo/app-redis.bicep
@@ -29,5 +29,20 @@ resource demoContainer 'Radius.Compute/containers@2025-08-01-preview' = {
         }
       }
     }
+    connections: {
+      redis: {
+        source: redis.id
+      }
+    }
   }
 }
+
+resource redis 'Radius.Data/redisCaches@2025-08-01-preview' = {
+  name: 'redis-${environmentName}'
+  properties: {
+    environment: environment
+    application: demoApp.id
+    size: 'S'
+  }
+}
+

--- a/samples/demo/app.bicep
+++ b/samples/demo/app.bicep
@@ -3,6 +3,9 @@ extension radius
 @description('The Radius Environment ID. Injected automatically by the rad CLI.')
 param environment string
 
+// Defaults to the published image; CI overrides this to test the freshly built image.
+param image string = 'ghcr.io/radius-project/samples/demo:latest'
+
 // Environment name derived from the Environment ID, used to keep resource names
 // unique per environment (e.g. dev/test/prod) within the same resource group.
 var environmentName = last(split(environment, '/'))
@@ -21,7 +24,7 @@ resource demoContainer 'Radius.Compute/containers@2025-08-01-preview' = {
     application: demoApp.id
     containers: {
       web: {
-        image: 'ghcr.io/radius-project/samples/demo:latest'
+        image: image
         ports: {
           web: {
             containerPort: 3000


### PR DESCRIPTION
## Summary

Updates the `demo` sample to the current `Radius.*` resource types and adds two datastore variants that show how to connect the demo container to a managed cache and database.

## Changes

- **`samples/demo/app.bicep`**
  - Migrate from deprecated `Applications.*` (`2023-10-01-preview`) to `Radius.*` (`2025-08-01-preview`) resource types.
  - Split into a dedicated `Radius.Core/applications` resource plus a `Radius.Compute/containers` resource using the new nested `containers` map schema.
  - Derive `environmentName` from the Environment ID and suffix resource names (`demo-${environmentName}`) so multiple environments (dev/test/prod) can coexist in the same resource group without name collisions.

- **`samples/demo/app-redis.bicep`** (new)
  - Demo container connected to a `Radius.Data/redisCaches` cache via a `connections.redis` link.

- **`samples/demo/app-postgresql.bicep`** (new)
  - Demo container connected to a `Radius.Data/postgreSqlDatabases` database via a `connections.postgresql` link.
  - Admin password supplied through a `@secure()` parameter (never stored in the file).

## Deploy

```sh
rad deploy samples/demo/app.bicep
rad deploy samples/demo/app-redis.bicep
rad deploy samples/demo/app-postgresql.bicep -p password=$(openssl rand -hex 16)