### PR TITLE
Demonstrate Redis connection secret variables

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,7 +76,7 @@ jobs:
             # Use the preview (Radius.*) resource types for expose/delete.
             previewFlag: true
             uiTestFile: tests/demo/demo.app.spec.ts
-            expectRedisConnectionUrl: true
+            expectRedisConnections: true
             port: 3000
             container: demo-default
             enableDapr: false
@@ -309,7 +309,7 @@ jobs:
         if: steps.gen-id.outputs.RUN_TEST == 'true' && matrix.uiTestFile != ''
         id: run-playwright-test
         env:
-          EXPECT_REDIS_CONNECTION_URL: ${{ matrix.expectRedisConnectionUrl }}
+          EXPECT_REDIS_CONNECTIONS: ${{ matrix.expectRedisConnections }}
         run: |
           if [[ "${{ matrix.container }}" != "" ]]; then
             if [[ "${{ matrix.previewFlag }}" == "true" ]]; then

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,7 +76,7 @@ jobs:
             # Use the preview (Radius.*) resource types for expose/delete.
             previewFlag: true
             uiTestFile: tests/demo/demo.app.spec.ts
-            expectRedisConnections: true
+            expectRedisConnection: true
             port: 3000
             container: demo-default
             enableDapr: false
@@ -309,7 +309,7 @@ jobs:
         if: steps.gen-id.outputs.RUN_TEST == 'true' && matrix.uiTestFile != ''
         id: run-playwright-test
         env:
-          EXPECT_REDIS_CONNECTIONS: ${{ matrix.expectRedisConnections }}
+          EXPECT_REDIS_CONNECTION: ${{ matrix.expectRedisConnection }}
         run: |
           if [[ "${{ matrix.container }}" != "" ]]; then
             if [[ "${{ matrix.previewFlag }}" == "true" ]]; then

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,6 +65,24 @@ jobs:
             images: samples/demo
             directories: samples/demo/
 
+          - name: demo-redis
+            os: ubuntu-24.04
+            runOnPullRequest: true
+            app: demo-default
+            env: default
+            path: ./samples/demo/app-redis.bicep
+            deployArgs: -p image=sampleregistry:5000/samples/demo
+            exposeArgs: --application demo-default
+            # Use the preview (Radius.*) resource types for expose/delete.
+            previewFlag: true
+            uiTestFile: tests/demo/demo.app.spec.ts
+            expectRedisConnectionUrl: true
+            port: 3000
+            container: demo-default
+            enableDapr: false
+            images: samples/demo
+            directories: samples/demo/
+
           - name: dapr
             os: ubuntu-24.04
             runOnPullRequest: true
@@ -290,6 +308,8 @@ jobs:
       - name: Run Playwright Test
         if: steps.gen-id.outputs.RUN_TEST == 'true' && matrix.uiTestFile != ''
         id: run-playwright-test
+        env:
+          EXPECT_REDIS_CONNECTION_URL: ${{ matrix.expectRedisConnectionUrl }}
         run: |
           if [[ "${{ matrix.container }}" != "" ]]; then
             if [[ "${{ matrix.previewFlag }}" == "true" ]]; then

--- a/playwright/tests/demo/demo.app.spec.ts
+++ b/playwright/tests/demo/demo.app.spec.ts
@@ -40,10 +40,12 @@ test("To-Do App Basic UI Checks", async ({ page }) => {
   await page.getByRole("link", { name: "Radius Demo" }).click();
 });
 
-test("Redis connection URL is injected", async ({ request }) => {
+test("Redis resource and secret connections are injected", async ({
+  request
+}) => {
   test.skip(
-    process.env.EXPECT_REDIS_CONNECTION_URL !== "true",
-    "Redis connection assertion is only enabled for the Redis demo"
+    process.env.EXPECT_REDIS_CONNECTIONS !== "true",
+    "Redis connection assertions are only enabled for the Redis demo"
   );
 
   const endpoint = process.env.ENDPOINT;
@@ -55,7 +57,8 @@ test("Redis connection URL is injected", async ({ request }) => {
   expect(response.ok()).toBeTruthy();
 
   const containerInfo = await response.json();
-  expect(containerInfo.env.CONNECTION_REDIS_URL).toBeTruthy();
+  expect(containerInfo.env.CONNECTION_REDIS_HOST).toBeTruthy();
+  expect(containerInfo.env.CONNECTION_REDISSECRET_URL).toBeTruthy();
 });
 
 test("Add an item and check basic functionality", async ({ page }) => {

--- a/playwright/tests/demo/demo.app.spec.ts
+++ b/playwright/tests/demo/demo.app.spec.ts
@@ -40,11 +40,11 @@ test("To-Do App Basic UI Checks", async ({ page }) => {
   await page.getByRole("link", { name: "Radius Demo" }).click();
 });
 
-test("Redis resource and secret connections are injected", async ({
+test("Redis connection injects resource and secret values", async ({
   request
 }) => {
   test.skip(
-    process.env.EXPECT_REDIS_CONNECTIONS !== "true",
+    process.env.EXPECT_REDIS_CONNECTION !== "true",
     "Redis connection assertions are only enabled for the Redis demo"
   );
 
@@ -58,7 +58,8 @@ test("Redis resource and secret connections are injected", async ({
 
   const containerInfo = await response.json();
   expect(containerInfo.env.CONNECTION_REDIS_HOST).toBeTruthy();
-  expect(containerInfo.env.CONNECTION_REDISSECRET_URL).toBeTruthy();
+  expect(containerInfo.env.CONNECTION_REDIS_PORT).toBeTruthy();
+  expect(containerInfo.env.CONNECTION_REDIS_URL).toBeTruthy();
 });
 
 test("Add an item and check basic functionality", async ({ page }) => {

--- a/playwright/tests/demo/demo.app.spec.ts
+++ b/playwright/tests/demo/demo.app.spec.ts
@@ -40,6 +40,24 @@ test("To-Do App Basic UI Checks", async ({ page }) => {
   await page.getByRole("link", { name: "Radius Demo" }).click();
 });
 
+test("Redis connection URL is injected", async ({ request }) => {
+  test.skip(
+    process.env.EXPECT_REDIS_CONNECTION_URL !== "true",
+    "Redis connection assertion is only enabled for the Redis demo"
+  );
+
+  const endpoint = process.env.ENDPOINT;
+  expect(endpoint).toBeDefined();
+
+  const response = await request.get(
+    new URL("/api/container-info", endpoint as string).toString()
+  );
+  expect(response.ok()).toBeTruthy();
+
+  const containerInfo = await response.json();
+  expect(containerInfo.env.CONNECTION_REDIS_URL).toBeTruthy();
+});
+
 test("Add an item and check basic functionality", async ({ page }) => {
   // Listen for all console events and handle errors
   page.on("console", (msg) => {
@@ -81,7 +99,7 @@ test("Add an item and check basic functionality", async ({ page }) => {
   await expect(
     page
       .getByRole("row", {
-        name: `${todoItem} lightbulb Complete done Delete delete`,
+        name: `${todoItem} lightbulb Complete done Delete delete`
       })
       .getByRole("button", { name: "Complete done" })
   ).toBeVisible();
@@ -89,7 +107,7 @@ test("Add an item and check basic functionality", async ({ page }) => {
   // We click the Complete button
   await page
     .getByRole("row", {
-      name: `${todoItem} lightbulb Complete done Delete delete`,
+      name: `${todoItem} lightbulb Complete done Delete delete`
     })
     .getByRole("button", { name: "Complete done" })
     .click();
@@ -98,7 +116,7 @@ test("Add an item and check basic functionality", async ({ page }) => {
   await expect(
     page
       .getByRole("row", {
-        name: `${todoItem} done Complete done Delete delete`,
+        name: `${todoItem} done Complete done Delete delete`
       })
       .getByRole("button", { name: "Complete done" })
   ).toBeVisible();
@@ -106,7 +124,7 @@ test("Add an item and check basic functionality", async ({ page }) => {
   // Delete a todo item
   await page
     .getByRole("row", {
-      name: `${todoItem} done Complete done Delete delete`,
+      name: `${todoItem} done Complete done Delete delete`
     })
     .getByRole("button", { name: "Delete delete" })
     .click();

--- a/samples/demo/README.md
+++ b/samples/demo/README.md
@@ -24,22 +24,10 @@ published demo image by default:
 rad deploy samples/demo/app-redis.bicep
 ```
 
-The Redis resource creates a `Radius.Security/secrets` resource containing its
-secret outputs. The template reads the generated name from
-`redis.properties.secrets.name` and combines it with the Radius resource group
-ID to form the Secret connection source. This discovers the generated resource;
-it does not create or manage a second secret.
+The `redis` connection provides both the Redis resource's non-secret values and
+its secret outputs. Radius injects `CONNECTION_REDIS_HOST` and
+`CONNECTION_REDIS_PORT` as normal environment variables, and injects the
+generated Secret's `url` key as `CONNECTION_REDIS_URL` through a Kubernetes
+`secretKeyRef`.
 
-Radius names environment variables from the connection name and each secret
-key as `CONNECTION_<CONNECTION-NAME>_<SECRET-KEY>`, normalized to uppercase.
-The template connects both resources so their properties remain distinct:
-
-- `redis` connects the `Radius.Data/redisCaches` resource and provides
-  non-secret values including `CONNECTION_REDIS_HOST` and
-  `CONNECTION_REDIS_PORT`.
-- `redisSecret` connects the generated `Radius.Security/secrets` resource. Its
-  `url` key becomes `CONNECTION_REDISSECRET_URL` without an explicit
-  `secretKeyRef`.
-
-The demo uses `CONNECTION_REDISSECRET_URL` for its Todo storage, while continuing
-to support `CONNECTION_REDIS_URL` and `REDIS_URL` for existing deployments.
+The demo uses `CONNECTION_REDIS_URL` for its Todo storage.

--- a/samples/demo/README.md
+++ b/samples/demo/README.md
@@ -25,9 +25,10 @@ rad deploy samples/demo/app-redis.bicep
 ```
 
 The Redis resource creates a `Radius.Security/secrets` resource containing its
-secret outputs. The template declares that generated resource as `existing`,
-using `redis.properties.secrets.name`. This declaration discovers the generated
-resource; it does not create or manage a second secret.
+secret outputs. The template reads the generated name from
+`redis.properties.secrets.name` and combines it with the Radius resource group
+ID to form the Secret connection source. This discovers the generated resource;
+it does not create or manage a second secret.
 
 Radius names environment variables from the connection name and each secret
 key as `CONNECTION_<CONNECTION-NAME>_<SECRET-KEY>`, normalized to uppercase.

--- a/samples/demo/README.md
+++ b/samples/demo/README.md
@@ -26,12 +26,19 @@ rad deploy samples/demo/app-redis.bicep
 
 The Redis resource creates a `Radius.Security/secrets` resource containing its
 secret outputs. The template declares that generated resource as `existing`,
-using `redis.properties.secrets.name`, and connects the container to the secret
-rather than directly to the Redis resource. This declaration discovers the
-generated resource; it does not create or manage a second secret.
+using `redis.properties.secrets.name`. This declaration discovers the generated
+resource; it does not create or manage a second secret.
 
 Radius names environment variables from the connection name and each secret
 key as `CONNECTION_<CONNECTION-NAME>_<SECRET-KEY>`, normalized to uppercase.
-For the `redis` connection and its `url` key, the demo receives
-`CONNECTION_REDIS_URL` without an explicit `secretKeyRef`. The demo uses that
-URL for its Todo storage.
+The template connects both resources so their properties remain distinct:
+
+- `redis` connects the `Radius.Data/redisCaches` resource and provides
+  non-secret values including `CONNECTION_REDIS_HOST` and
+  `CONNECTION_REDIS_PORT`.
+- `redisSecret` connects the generated `Radius.Security/secrets` resource. Its
+  `url` key becomes `CONNECTION_REDISSECRET_URL` without an explicit
+  `secretKeyRef`.
+
+The demo uses `CONNECTION_REDISSECRET_URL` for its Todo storage, while continuing
+to support `CONNECTION_REDIS_URL` and `REDIS_URL` for existing deployments.

--- a/samples/demo/README.md
+++ b/samples/demo/README.md
@@ -14,3 +14,24 @@ docker build \
   --tag radius-demo:local \
   samples/demo
 ```
+
+## Deploy the Redis demo
+
+`app-redis.bicep` deploys the demo application with a Redis cache and uses the
+published demo image by default:
+
+```sh
+rad deploy samples/demo/app-redis.bicep
+```
+
+The Redis resource creates a `Radius.Security/secrets` resource containing its
+secret outputs. The template declares that generated resource as `existing`,
+using `redis.properties.secrets.name`, and connects the container to the secret
+rather than directly to the Redis resource. This declaration discovers the
+generated resource; it does not create or manage a second secret.
+
+Radius names environment variables from the connection name and each secret
+key as `CONNECTION_<CONNECTION-NAME>_<SECRET-KEY>`, normalized to uppercase.
+For the `redis` connection and its `url` key, the demo receives
+`CONNECTION_REDIS_URL` without an explicit `secretKeyRef`. The demo uses that
+URL for its Todo storage.

--- a/samples/demo/app-redis.bicep
+++ b/samples/demo/app-redis.bicep
@@ -3,6 +3,9 @@ extension radius
 @description('The Radius Environment ID. Injected automatically by the rad CLI.')
 param environment string
 
+// Defaults to the published image; CI overrides this to test the freshly built image.
+param image string = 'ghcr.io/radius-project/samples/demo:latest'
+
 // Environment name derived from the Environment ID, used to keep resource names
 // unique per environment (e.g. dev/test/prod) within the same resource group.
 var environmentName = last(split(environment, '/'))
@@ -21,7 +24,7 @@ resource demoContainer 'Radius.Compute/containers@2025-08-01-preview' = {
     application: demoApp.id
     containers: {
       web: {
-        image: 'ghcr.io/radius-project/samples/demo:latest'
+        image: image
         ports: {
           web: {
             containerPort: 3000
@@ -31,7 +34,7 @@ resource demoContainer 'Radius.Compute/containers@2025-08-01-preview' = {
     }
     connections: {
       redis: {
-        source: redis.id
+        source: redisSecret.id
       }
     }
   }
@@ -46,3 +49,6 @@ resource redis 'Radius.Data/redisCaches@2025-08-01-preview' = {
   }
 }
 
+resource redisSecret 'Radius.Security/secrets@2025-08-01-preview' existing = {
+  name: redis.properties.secrets.name
+}

--- a/samples/demo/app-redis.bicep
+++ b/samples/demo/app-redis.bicep
@@ -9,6 +9,9 @@ param image string = 'ghcr.io/radius-project/samples/demo:latest'
 // Environment name derived from the Environment ID, used to keep resource names
 // unique per environment (e.g. dev/test/prod) within the same resource group.
 var environmentName = last(split(environment, '/'))
+// Connections require a full resource ID. The environment and generated Secret
+// share a Radius resource group, so retain the environment ID through that scope.
+var resourceGroupId = take(environment, lastIndexOf(environment, '/providers/'))
 
 resource demoApp 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'demo-${environmentName}'
@@ -37,7 +40,7 @@ resource demoContainer 'Radius.Compute/containers@2025-08-01-preview' = {
         source: redis.id
       }
       redisSecret: {
-        source: redisSecret.id
+        source: '${resourceGroupId}/providers/Radius.Security/secrets/${redis.properties.secrets.name}'
       }
     }
   }
@@ -50,8 +53,4 @@ resource redis 'Radius.Data/redisCaches@2025-08-01-preview' = {
     application: demoApp.id
     size: 'S'
   }
-}
-
-resource redisSecret 'Radius.Security/secrets@2025-08-01-preview' existing = {
-  name: redis.properties.secrets.name
 }

--- a/samples/demo/app-redis.bicep
+++ b/samples/demo/app-redis.bicep
@@ -34,6 +34,9 @@ resource demoContainer 'Radius.Compute/containers@2025-08-01-preview' = {
     }
     connections: {
       redis: {
+        source: redis.id
+      }
+      redisSecret: {
         source: redisSecret.id
       }
     }

--- a/samples/demo/app-redis.bicep
+++ b/samples/demo/app-redis.bicep
@@ -9,9 +9,6 @@ param image string = 'ghcr.io/radius-project/samples/demo:latest'
 // Environment name derived from the Environment ID, used to keep resource names
 // unique per environment (e.g. dev/test/prod) within the same resource group.
 var environmentName = last(split(environment, '/'))
-// Connections require a full resource ID. The environment and generated Secret
-// share a Radius resource group, so retain the environment ID through that scope.
-var resourceGroupId = take(environment, lastIndexOf(environment, '/providers/'))
 
 resource demoApp 'Radius.Core/applications@2025-08-01-preview' = {
   name: 'demo-${environmentName}'
@@ -38,9 +35,6 @@ resource demoContainer 'Radius.Compute/containers@2025-08-01-preview' = {
     connections: {
       redis: {
         source: redis.id
-      }
-      redisSecret: {
-        source: '${resourceGroupId}/providers/Radius.Security/secrets/${redis.properties.secrets.name}'
       }
     }
   }

--- a/samples/demo/src/db/repository.ts
+++ b/samples/demo/src/db/repository.ts
@@ -36,42 +36,9 @@ export function createFactory(): RepositoryFactory {
         return new MongoFactory(process.env.CONNECTION_MONGODB_CONNECTIONSTRING);
     }
 
-    if (process.env.CONNECTION_REDISSECRET_URL) {
-        console.log("Using Redis: found url in environment variable CONNECTION_REDISSECRET_URL");
-        return new RedisFactory(process.env.CONNECTION_REDISSECRET_URL);
-    }
-
     if (process.env.CONNECTION_REDIS_URL) {
         console.log("Using Redis: found url in environment variable CONNECTION_REDIS_URL");
         return new RedisFactory(process.env.CONNECTION_REDIS_URL);
-    }
-
-    if (process.env.REDIS_URL) {
-        console.log("Using Redis: found url in environment variable REDIS_URL");
-        return new RedisFactory(process.env.REDIS_URL);
-    }
-
-    if (process.env.CONNECTION_REDIS_HOST) {
-        console.log("Using Redis: found hostname in environment variable CONNECTION_REDIS_HOST");
-        const connection = {
-            host: process.env.CONNECTION_REDIS_HOST!,
-            port: process.env.CONNECTION_REDIS_PORT!,
-            username: process.env.CONNECTION_REDIS_USERNAME || '',
-            password: process.env.CONNECTION_REDIS_PASSWORD || '',
-        }
-
-        let scheme = "redis"
-        if (connection.port === "6380") {
-            scheme = "rediss"
-        }
-
-        let usernamePass = "";
-        if (connection.username !== "" || connection.password !== "") {
-            usernamePass = `${connection.username}:${connection.password}@`
-        }
-
-        const url = `${scheme}://${usernamePass}${connection.host}:${connection.port}`
-        return new RedisFactory(url);
     }
 
     if (process.env.CONNECTION_POSTGRESQL_HOST) {

--- a/samples/demo/src/db/repository.ts
+++ b/samples/demo/src/db/repository.ts
@@ -36,9 +36,19 @@ export function createFactory(): RepositoryFactory {
         return new MongoFactory(process.env.CONNECTION_MONGODB_CONNECTIONSTRING);
     }
 
+    if (process.env.CONNECTION_REDISSECRET_URL) {
+        console.log("Using Redis: found url in environment variable CONNECTION_REDISSECRET_URL");
+        return new RedisFactory(process.env.CONNECTION_REDISSECRET_URL);
+    }
+
     if (process.env.CONNECTION_REDIS_URL) {
         console.log("Using Redis: found url in environment variable CONNECTION_REDIS_URL");
         return new RedisFactory(process.env.CONNECTION_REDIS_URL);
+    }
+
+    if (process.env.REDIS_URL) {
+        console.log("Using Redis: found url in environment variable REDIS_URL");
+        return new RedisFactory(process.env.REDIS_URL);
     }
 
     if (process.env.CONNECTION_REDIS_HOST) {


### PR DESCRIPTION
## Summary

- connect the demo container to Redis with a single `redis` connection whose source is `redis.id`
- demonstrate `CONNECTION_REDIS_HOST` and `CONNECTION_REDIS_PORT` as normal environment values from that connection
- demonstrate `CONNECTION_REDIS_URL` as a secret-backed environment value injected through Kubernetes `secretKeyRef`
- remove the extra generated-Secret connection and manual Secret resource ID reconstruction
- make the Todo repository consume only `CONNECTION_REDIS_URL`, removing legacy URL and host/port construction fallbacks
- keep environment-qualified application, container, and Redis names for concurrent CI runs
- add the Redis demo workflow entry and verify HOST, PORT, and URL injection in Playwright

## Dependencies

Depends on radius-project/radius#12709 and radius-project/resource-types-contrib#300. This PR demonstrates the runtime capability but does not implement it.

## Validation

- `bicep format samples/demo/app-redis.bicep`
- `bicep build samples/demo/app-redis.bicep --stdout`
- `npm --prefix samples/demo run build`
- parsed `.github/workflows/test.yaml`
- discovered all 9 demo Playwright tests across Chromium, Firefox, and WebKit
- `git diff --check`

## Notes

The existing native Kubernetes `secretKeyRef` samples continue to use `<producer>.properties.secrets.name`; this PR does not change those consumers.