### PR TITLE
Update PostgreSQL demo secret connection

### DIFF
--- a/samples/demo/README.md
+++ b/samples/demo/README.md
@@ -14,3 +14,10 @@ docker build \
   --tag radius-demo:local \
   samples/demo
 ```
+
+## PostgreSQL variant
+
+`app-postgresql.bicep` uses the Kubernetes Container Recipe's direct Secret connection support to project the database password as `CONNECTION_POSTGRESQLCREDENTIALS_PASSWORD`. This requires a Radius edge installation containing the Kubernetes Recipe contract from
+[`radius-project/resource-types-contrib#300`](https://github.com/radius-project/resource-types-contrib/pull/300).
+
+The demo image prefers that variable and retains `CONNECTION_POSTGRESQL_PASSWORD` as a compatibility fallback for older or mixed installations whose PostgreSQL Recipe still supplies the password. If both variables are present, they must match. Azure ACI does not project direct Secret connections, so this new password path is Kubernetes-only; its existing connection behavior is unchanged.

--- a/samples/demo/README.md
+++ b/samples/demo/README.md
@@ -17,7 +17,6 @@ docker build \
 
 ## PostgreSQL variant
 
-`app-postgresql.bicep` uses the Kubernetes Container Recipe's direct Secret connection support to project the database password as `CONNECTION_POSTGRESQLCREDENTIALS_PASSWORD`. This requires a Radius edge installation containing the Kubernetes Recipe contract from
-[`radius-project/resource-types-contrib#300`](https://github.com/radius-project/resource-types-contrib/pull/300).
+`app-postgresql.bicep` uses the Kubernetes Container Recipe's direct Secret connection support to project the database password as `CONNECTION_POSTGRESQLCREDENTIALS_PASSWORD`. This requires Radius 0.61.0 or later, or a current edge installation.
 
-The demo image prefers that variable and retains `CONNECTION_POSTGRESQL_PASSWORD` as a compatibility fallback for older or mixed installations whose PostgreSQL Recipe still supplies the password. If both variables are present, they must match. Azure ACI does not project direct Secret connections, so this new password path is Kubernetes-only; its existing connection behavior is unchanged.
+The demo image prefers that variable and retains `CONNECTION_POSTGRESQL_PASSWORD` as a compatibility fallback for older or mixed installations whose PostgreSQL Recipe still supplies the password. If both variables are set to different values, the demo logs a warning and uses `CONNECTION_POSTGRESQLCREDENTIALS_PASSWORD`. Azure ACI does not project direct Secret connections, so this new password path is Kubernetes-only; its existing connection behavior is unchanged.

--- a/samples/demo/app-postgresql.bicep
+++ b/samples/demo/app-postgresql.bicep
@@ -37,8 +37,8 @@ resource demoContainer 'Radius.Compute/containers@2025-08-01-preview' = {
       postgresql: {
         source: postgresql.id
       }
-      postgresqlcredentials: {
-        source: postgresqlClientCredentials.id
+      postgresqlCredentials: {
+        source: postgresqlCredentials.id
       }
     }
   }
@@ -56,8 +56,8 @@ resource postgresql 'Radius.Data/postgreSqlDatabases@2025-08-01-preview' = {
   }
 }
 
-resource postgresqlClientCredentials 'Radius.Security/secrets@2025-08-01-preview' = {
-  name: 'postgresql-client-credentials-${environmentName}'
+resource postgresqlCredentials 'Radius.Security/secrets@2025-08-01-preview' = {
+  name: 'postgresql-credentials-${environmentName}'
   properties: {
     environment: environment
     application: demoApp.id

--- a/samples/demo/app-postgresql.bicep
+++ b/samples/demo/app-postgresql.bicep
@@ -56,8 +56,6 @@ resource postgresql 'Radius.Data/postgreSqlDatabases@2025-08-01-preview' = {
   }
 }
 
-// Keep this distinct from the PostgreSQL Recipe-owned
-// `postgresql-${environmentName}-credentials` Kubernetes Secret.
 resource postgresqlClientCredentials 'Radius.Security/secrets@2025-08-01-preview' = {
   name: 'postgresql-client-credentials-${environmentName}'
   properties: {

--- a/samples/demo/app-postgresql.bicep
+++ b/samples/demo/app-postgresql.bicep
@@ -37,6 +37,9 @@ resource demoContainer 'Radius.Compute/containers@2025-08-01-preview' = {
       postgresql: {
         source: postgresql.id
       }
+      postgresqlcredentials: {
+        source: postgresqlClientCredentials.id
+      }
     }
   }
 }
@@ -50,5 +53,20 @@ resource postgresql 'Radius.Data/postgreSqlDatabases@2025-08-01-preview' = {
     database: 'appdb'
     username: 'myadmin'
     password: password
+  }
+}
+
+// Keep this distinct from the PostgreSQL Recipe-owned
+// `postgresql-${environmentName}-credentials` Kubernetes Secret.
+resource postgresqlClientCredentials 'Radius.Security/secrets@2025-08-01-preview' = {
+  name: 'postgresql-client-credentials-${environmentName}'
+  properties: {
+    environment: environment
+    application: demoApp.id
+    data: {
+      password: {
+        value: password
+      }
+    }
   }
 }

--- a/samples/demo/src/db/repository.ts
+++ b/samples/demo/src/db/repository.ts
@@ -66,19 +66,19 @@ export function createFactory(): RepositoryFactory {
 
     if (process.env.CONNECTION_POSTGRESQL_HOST) {
         console.log("Using PostgreSQL: found hostname in environment variable CONNECTION_POSTGRESQL_HOST");
-        const secretConnectionPassword = process.env.CONNECTION_POSTGRESQLCREDENTIALS_PASSWORD;
-        const legacyConnectionPassword = process.env.CONNECTION_POSTGRESQL_PASSWORD;
-        if (secretConnectionPassword !== undefined &&
-            legacyConnectionPassword !== undefined &&
+        const secretConnectionPassword = process.env.CONNECTION_POSTGRESQLCREDENTIALS_PASSWORD || undefined;
+        const legacyConnectionPassword = process.env.CONNECTION_POSTGRESQL_PASSWORD || undefined;
+        if (secretConnectionPassword &&
+            legacyConnectionPassword &&
             secretConnectionPassword !== legacyConnectionPassword) {
-            throw new Error("Conflicting PostgreSQL passwords found in CONNECTION_POSTGRESQLCREDENTIALS_PASSWORD and CONNECTION_POSTGRESQL_PASSWORD");
+            console.warn("Conflicting PostgreSQL passwords found; using CONNECTION_POSTGRESQLCREDENTIALS_PASSWORD instead of CONNECTION_POSTGRESQL_PASSWORD");
         }
 
         const connection = {
             host: process.env.CONNECTION_POSTGRESQL_HOST!,
             port: process.env.CONNECTION_POSTGRESQL_PORT!,
             username: process.env.CONNECTION_POSTGRESQL_USERNAME || '',
-            password: secretConnectionPassword ?? legacyConnectionPassword ?? '',
+            password: secretConnectionPassword || legacyConnectionPassword || '',
             database: process.env.CONNECTION_POSTGRESQL_DATABASE || '',
         }
         const url = `postgresql://${connection.username}:${connection.password}@${connection.host}:${connection.port}/${connection.database}`

--- a/samples/demo/src/db/repository.ts
+++ b/samples/demo/src/db/repository.ts
@@ -66,11 +66,19 @@ export function createFactory(): RepositoryFactory {
 
     if (process.env.CONNECTION_POSTGRESQL_HOST) {
         console.log("Using PostgreSQL: found hostname in environment variable CONNECTION_POSTGRESQL_HOST");
+        const secretConnectionPassword = process.env.CONNECTION_POSTGRESQLCREDENTIALS_PASSWORD;
+        const legacyConnectionPassword = process.env.CONNECTION_POSTGRESQL_PASSWORD;
+        if (secretConnectionPassword !== undefined &&
+            legacyConnectionPassword !== undefined &&
+            secretConnectionPassword !== legacyConnectionPassword) {
+            throw new Error("Conflicting PostgreSQL passwords found in CONNECTION_POSTGRESQLCREDENTIALS_PASSWORD and CONNECTION_POSTGRESQL_PASSWORD");
+        }
+
         const connection = {
             host: process.env.CONNECTION_POSTGRESQL_HOST!,
             port: process.env.CONNECTION_POSTGRESQL_PORT!,
             username: process.env.CONNECTION_POSTGRESQL_USERNAME || '',
-            password: process.env.CONNECTION_POSTGRESQL_PASSWORD || '',
+            password: secretConnectionPassword ?? legacyConnectionPassword ?? '',
             database: process.env.CONNECTION_POSTGRESQL_DATABASE || '',
         }
         const url = `postgresql://${connection.username}:${connection.password}@${connection.host}:${connection.port}/${connection.database}`


### PR DESCRIPTION
## Summary

Updates the getting-started PostgreSQL demo to use the newly merged direct `Radius.Security/secrets` connection contract on Kubernetes.

- Authors a separate `postgresql-credentials-*` Radius Secret containing the same developer-supplied password passed by value to PostgreSQL.
- Keeps the `postgresql` database connection for host, port, database, username, and dependency ordering.
- Adds the `postgresqlCredentials` Secret connection, which projects `CONNECTION_POSTGRESQLCREDENTIALS_PASSWORD` through a Kubernetes `secretKeyRef`.
- Prefers the new non-empty variable while retaining `CONNECTION_POSTGRESQL_PASSWORD` as an older/mixed-installation fallback; differing non-empty values log a warning and use the new value.

## Reason for change

[radius-project/radius#12709](https://github.com/radius-project/radius/pull/12709) and [radius-project/resource-types-contrib#300](https://github.com/radius-project/resource-types-contrib/pull/300) added direct Secret connection projection. [radius-project/resource-types-contrib#298](https://github.com/radius-project/resource-types-contrib/pull/298) corrected PostgreSQL secret ownership so the Recipe no longer returns the developer-supplied password as a managed output. The demo now supplies that credential through its own Secret.

This remains backward compatible while installations transition: older PostgreSQL Recipes continue to provide `CONNECTION_POSTGRESQL_PASSWORD`, newer Kubernetes Recipes provide `CONNECTION_POSTGRESQLCREDENTIALS_PASSWORD`, and the new non-empty value takes precedence when both are present. The new direct Secret projection is Kubernetes-only; Azure ACI connection behavior is unchanged.

The repository's `Build samples` workflow builds `ghcr.io/radius-project/samples/demo:latest` for pull requests without pushing it. A push to `edge` builds and publishes that `latest` tag, so no image was manually published for this PR.

## How to test

- `npm run build` in `samples/demo`
- Runtime assertions for preferred, fallback, empty preferred, and differing dual-value password cases
- `BICEP_PATH="$HOME/.rad/bin" python3 ./.github/scripts/validate_bicep.py`
- `bicep format samples/demo/app-postgresql.bicep --stdout` diff check
- `git diff --check`

Rebased onto current `edge`, including [#2657](https://github.com/radius-project/samples/pull/2657)'s explicit Radius environment setup fix. Local formatting, TypeScript/client builds, password compatibility assertions, and Bicep validation pass. Refreshed CI is running.

## File change summary

| File | Summary of change |
| ---- | ----------------- |
| `samples/demo/app-postgresql.bicep` | Adds a consistently named client credential Secret and direct Secret connection. |
| `samples/demo/src/db/repository.ts` | Prefers the new non-empty password variable, retains the legacy fallback, and warns on conflicts. |
| `samples/demo/README.md` | Documents the minimum release, Kubernetes variable contract, fallback behavior, and ACI scope. |
